### PR TITLE
fix: repair LobsterGym eval pipeline

### DIFF
--- a/.devcontainer/docker-compose.test.yml
+++ b/.devcontainer/docker-compose.test.yml
@@ -63,7 +63,17 @@ services:
         mkdir -p /root/.openclaw/workspace/skills &&
         cp -r /workspace/skills/clawgraph /root/.openclaw/workspace/skills/ &&
         pip install -e /workspace &&
-        echo '{\"agent\": {\"model\": \"openai/gpt-4o-mini\"}}' > /root/.openclaw/openclaw.json &&
+        cat > /root/.openclaw/openclaw.json << 'CONF'
+        {
+          "agents": {
+            "defaults": {
+              "model": {
+                "primary": "openai/gpt-4o-mini"
+              }
+            }
+          }
+        }
+        CONF
         echo '=== Starting OpenClaw gateway on port 18789 ===' &&
         echo 'WebChat/Control UI: http://127.0.0.1:18789/' &&
         openclaw gateway --port 18789 --verbose

--- a/lobstergym/docker-compose.yml
+++ b/lobstergym/docker-compose.yml
@@ -71,8 +71,12 @@ services:
         pip install -e /workspace 2>/dev/null &&
         cat > /root/.openclaw/openclaw.json << 'CONF'
         {
-          \"agent\": {
-            \"model\": \"openai/gpt-4o-mini\"
+          \"agents\": {
+            \"defaults\": {
+              \"model\": {
+                \"primary\": \"openai/gpt-4o-mini\"
+              }
+            }
           },
           \"browser\": {
             \"enabled\": true,
@@ -99,6 +103,7 @@ services:
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - LITELLM_LOCAL_MODEL_COST_MAP=True
     volumes:
       - ..:/workspace:cached
       - openclaw-default-home:/root/.openclaw
@@ -113,8 +118,12 @@ services:
         echo '=== OpenClaw Default Gateway ===' &&
         cat > /root/.openclaw/openclaw.json << 'CONF'
         {
-          \"agent\": {
-            \"model\": \"openai/gpt-4o-mini\"
+          \"agents\": {
+            \"defaults\": {
+              \"model\": {
+                \"primary\": \"openai/gpt-4o-mini\"
+              }
+            }
           },
           \"browser\": {
             \"enabled\": true,
@@ -136,21 +145,48 @@ services:
     build:
       context: ..
       dockerfile: .devcontainer/Dockerfile
-    network_mode: "service:openclaw-clawgraph"
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - LOBSTERGYM_WEB_BASE=http://lobstergym-web:8080
+      - LOBSTERGYM_API_BASE=http://lobstergym-api:8090
+      - LITELLM_LOCAL_MODEL_COST_MAP=True
     volumes:
       - ..:/workspace:cached
       - openclaw-clawgraph-home:/root/.openclaw
     working_dir: /workspace
     depends_on:
-      - openclaw-clawgraph
+      lobstergym-web:
+        condition: service_healthy
+      lobstergym-api:
+        condition: service_healthy
     entrypoint: ["bash", "-c"]
     command:
       - |
         echo '🦞 LobsterGym Eval — ClawGraph Profile'
+        mkdir -p /root/.openclaw/workspace/skills
+        rm -rf /root/.openclaw/workspace/skills/clawgraph
+        cp -r /workspace/skills/clawgraph /root/.openclaw/workspace/skills/
         pip install -e /workspace 2>/dev/null
         pip install requests 2>/dev/null
+        cat > /root/.openclaw/openclaw.json << 'CONF'
+        {
+          "agents": {
+            "defaults": {
+              "model": {
+                "primary": "openai/gpt-4o-mini"
+              }
+            }
+          },
+          "browser": {
+            "enabled": true,
+            "headless": true,
+            "noSandbox": true,
+            "ssrfPolicy": {
+              "dangerouslyAllowPrivateNetwork": true
+            }
+          }
+        }
+        CONF
         python -m lobstergym.eval.runner \
           --profile clawgraph \
           --output /workspace/lobstergym/reports/eval-clawgraph.json
@@ -164,19 +200,44 @@ services:
     build:
       context: ..
       dockerfile: .devcontainer/Dockerfile
-    network_mode: "service:openclaw-default"
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - LOBSTERGYM_WEB_BASE=http://lobstergym-web:8080
+      - LOBSTERGYM_API_BASE=http://lobstergym-api:8090
+      - LITELLM_LOCAL_MODEL_COST_MAP=True
     volumes:
       - ..:/workspace:cached
       - openclaw-default-home:/root/.openclaw
     working_dir: /workspace
     depends_on:
-      - openclaw-default
+      lobstergym-web:
+        condition: service_healthy
+      lobstergym-api:
+        condition: service_healthy
     entrypoint: ["bash", "-c"]
     command:
       - |
         echo '🦞 LobsterGym Eval — Default Profile'
+        cat > /root/.openclaw/openclaw.json << 'CONF'
+        {
+          "agents": {
+            "defaults": {
+              "model": {
+                "primary": "openai/gpt-4o-mini"
+              }
+            }
+          },
+          "browser": {
+            "enabled": true,
+            "headless": true,
+            "noSandbox": true,
+            "ssrfPolicy": {
+              "dangerouslyAllowPrivateNetwork": true
+            }
+          }
+        }
+        CONF
+        pip install -e /workspace 2>/dev/null
         pip install requests 2>/dev/null
         python -m lobstergym.eval.runner \
           --profile default \

--- a/lobstergym/eval/runner.py
+++ b/lobstergym/eval/runner.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 import time
@@ -29,9 +30,8 @@ from .tasks import TASKS, Category, Check, Difficulty, Task, get_tasks
 # Configuration
 # ---------------------------------------------------------------------------
 
-WEB_BASE = "http://lobstergym-web:8080"
-API_BASE = "http://lobstergym-api:8090"
-OPENCLAW_GATEWAY = "http://127.0.0.1:18789"
+WEB_BASE = os.getenv("LOBSTERGYM_WEB_BASE", "http://lobstergym-web:8080")
+API_BASE = os.getenv("LOBSTERGYM_API_BASE", "http://lobstergym-api:8090")
 
 # How long to wait for the agent to finish a task (seconds)
 TASK_TIMEOUT = 120
@@ -267,7 +267,9 @@ def _summarize(val: Any, max_len: int = 200) -> Any:
 def send_task_to_agent(instruction: str) -> str:
     """Send a task instruction to the OpenClaw agent.
 
-    Uses ``openclaw agent --message`` CLI for simplicity.
+    Uses ``openclaw agent --local --message`` so the eval runs inside the
+    current container/network namespace and can resolve the mock service
+    hostnames directly.
 
     Args:
         instruction: Natural-language instruction.
@@ -277,7 +279,7 @@ def send_task_to_agent(instruction: str) -> str:
     """
     try:
         result = subprocess.run(
-            ["openclaw", "agent", "--message", instruction],
+            ["openclaw", "agent", "--local", "--message", instruction],
             capture_output=True,
             text=True,
             timeout=TASK_TIMEOUT,


### PR DESCRIPTION
This fixes the LobsterGym CI/eval pipeline failing before tasks can run.

## Root causes
- OpenClaw config written by compose used the old gent.model schema
- Eval runners could not resolve lobstergym-web / lobstergym-api reliably due to their network setup
- openclaw agent was failing before real task execution because the config was invalid

## Changes
- update OpenClaw config to current schema using gents.defaults.model.primary
- run eval agent turns with openclaw agent --local
- keep eval containers on the compose network so mock service DNS works
- make eval runner read service base URLs from env vars
- update the devcontainer OpenClaw test config to the current schema too

## Notes
- docker compose config validation passes for both compose files
- this PR is focused on restoring pipeline health