### PR TITLE
fix: repair lobstergym eval pipeline — gateway, routing, CI

### DIFF
--- a/.devcontainer/docker-compose.test.yml
+++ b/.devcontainer/docker-compose.test.yml
@@ -65,18 +65,29 @@ services:
         pip install -e /workspace &&
         cat > /root/.openclaw/openclaw.json << 'CONF'
         {
-          "agents": {
-            "defaults": {
-              "model": {
-                "primary": "openai/gpt-4o-mini"
+              "gateway": {
+                "mode": "local",
+                "bind": "lan",
+                "controlUi": {
+                  "enabled": true,
+                  "allowedOrigins": [
+                    "http://localhost:18789",
+                    "http://127.0.0.1:18789"
+                  ]
+                }
+              },
+              "agents": {
+                "defaults": {
+                  "model": {
+                    "primary": "openai/gpt-5-mini"
+                  }
+                }
               }
-            }
-          }
         }
         CONF
         echo '=== Starting OpenClaw gateway on port 18789 ===' &&
         echo 'WebChat/Control UI: http://127.0.0.1:18789/' &&
-        openclaw gateway --port 18789 --verbose
+        openclaw gateway --bind lan --port 18789 --verbose
       "
 
   # Send a message to the running OpenClaw agent and inspect the response

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,12 +108,22 @@ jobs:
             sleep 2
           done
 
+      - name: Smoke check — ClawGraph profile
+        working-directory: lobstergym
+        run: docker compose run --rm smoke-clawgraph
+
+      - name: Smoke check — Default profile
+        working-directory: lobstergym
+        run: docker compose run --rm smoke-default
+
       - name: Run eval — ClawGraph profile
         working-directory: lobstergym
+        continue-on-error: true
         run: docker compose run --rm eval-clawgraph
 
       - name: Run eval — Default profile
         working-directory: lobstergym
+        continue-on-error: true
         run: docker compose run --rm eval-default
 
       - name: Upload eval reports

--- a/lobstergym/api/app.py
+++ b/lobstergym/api/app.py
@@ -48,6 +48,12 @@ WEATHER_DATA: dict[str, dict[str, Any]] = {
 weather_queries: list[dict[str, Any]] = []
 
 
+@app.get("/weather/state")
+def weather_state() -> dict[str, Any]:
+    """Eval harness inspection."""
+    return {"queries": weather_queries}
+
+
 @app.get("/weather/{city}")
 def get_weather(city: str) -> dict[str, Any]:
     """Get current weather for a city."""
@@ -56,12 +62,6 @@ def get_weather(city: str) -> dict[str, Any]:
     if key not in WEATHER_DATA:
         raise HTTPException(status_code=404, detail=f"No weather data for '{city}'")
     return {"city": city, **WEATHER_DATA[key]}
-
-
-@app.get("/weather/state")
-def weather_state() -> dict[str, Any]:
-    """Eval harness inspection."""
-    return {"queries": weather_queries}
 
 
 # ===================================================================
@@ -276,6 +276,12 @@ notes: list[dict[str, Any]] = [
 ]
 
 
+@app.get("/notes/state")
+def notes_state() -> dict[str, Any]:
+    """Eval harness inspection."""
+    return {"notes": notes}
+
+
 @app.get("/notes")
 def list_notes(tag: str | None = None) -> dict[str, Any]:
     """List all notes, optionally filtered by tag."""
@@ -328,12 +334,6 @@ def delete_note(note_id: str) -> MessageResponse:
     if len(notes) == before:
         raise HTTPException(status_code=404, detail="Note not found")
     return MessageResponse(message="Note deleted")
-
-
-@app.get("/notes/state")
-def notes_state() -> dict[str, Any]:
-    """Eval harness inspection."""
-    return {"notes": notes}
 
 
 # ===================================================================

--- a/lobstergym/docker-compose.yml
+++ b/lobstergym/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 # =======================================================================
 # LobsterGym — Full evaluation stack
 #
@@ -50,8 +48,21 @@ services:
       dockerfile: .devcontainer/Dockerfile
     ports:
       - "18789:18789"
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import socket; s=socket.create_connection(('127.0.0.1', 18789), 5); s.close()",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 30s
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - OPENCLAW_GATEWAY_TOKEN=${OPENCLAW_GATEWAY_TOKEN:-lobstergym-dev-token}
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
       - LITELLM_LOCAL_MODEL_COST_MAP=True
     volumes:
@@ -63,33 +74,66 @@ services:
         condition: service_healthy
       lobstergym-api:
         condition: service_healthy
-    command: >
-      bash -c "
-        echo '=== OpenClaw + ClawGraph Gateway ===' &&
-        mkdir -p /root/.openclaw/workspace/skills &&
-        cp -r /workspace/skills/clawgraph /root/.openclaw/workspace/skills/ &&
-        pip install -e /workspace 2>/dev/null &&
-        cat > /root/.openclaw/openclaw.json << 'CONF'
+    entrypoint: ["bash", "-lc"]
+    command:
+      - |
+        echo '=== OpenClaw + ClawGraph Gateway ==='
+        mkdir -p /root/.openclaw/workspace/skills
+        cp -r /workspace/skills/clawgraph /root/.openclaw/workspace/skills/
+        pip install -e /workspace 2>/dev/null
+        cat > /root/.openclaw/openclaw.json << CONF
         {
-          \"agents\": {
-            \"defaults\": {
-              \"model\": {
-                \"primary\": \"openai/gpt-4o-mini\"
+          "gateway": {
+            "mode": "local",
+            "bind": "lan",
+            "auth": {
+              "mode": "token",
+              "token": "$${OPENCLAW_GATEWAY_TOKEN:-lobstergym-dev-token}"
+            },
+            "controlUi": {
+              "enabled": true,
+              "dangerouslyDisableDeviceAuth": true,
+              "allowInsecureAuth": true,
+              "allowedOrigins": [
+                "http://localhost:18789",
+                "http://127.0.0.1:18789",
+                "http://localhost:18790",
+                "http://127.0.0.1:18790"
+              ]
+            }
+          },
+          "agents": {
+            "defaults": {
+              "model": {
+                "primary": "openai/gpt-5-mini"
               }
             }
           },
-          \"browser\": {
-            \"enabled\": true,
-            \"headless\": true,
-            \"noSandbox\": true,
-            \"ssrfPolicy\": {
-              \"dangerouslyAllowPrivateNetwork\": true
+          "browser": {
+            "enabled": true,
+            "headless": true,
+            "noSandbox": true,
+            "ssrfPolicy": {
+              "dangerouslyAllowPrivateNetwork": true
             }
           }
         }
-      CONF
-        openclaw gateway --port 18789 --verbose
-      "
+        CONF
+        openclaw gateway --bind lan --port 18789 --verbose &
+        GATEWAY_PID=$$!
+        for i in $(seq 1 60); do
+          if python - <<'PY' >/dev/null 2>&1
+        import socket
+        s = socket.create_connection(("127.0.0.1", 18789), 2)
+        s.close()
+        PY
+          then
+            echo 'OPENCLAW_GATEWAY_READY profile=clawgraph port=18789'
+            break
+          fi
+          sleep 1
+        done
+        wait $$GATEWAY_PID
 
   # -------------------------------------------------------------------
   # OpenClaw gateway WITHOUT ClawGraph (default profile for comparison)
@@ -100,8 +144,21 @@ services:
       dockerfile: .devcontainer/Dockerfile
     ports:
       - "18790:18789"
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import socket; s=socket.create_connection(('127.0.0.1', 18789), 5); s.close()",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 30s
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - OPENCLAW_GATEWAY_TOKEN=${OPENCLAW_GATEWAY_TOKEN:-lobstergym-dev-token}
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
       - LITELLM_LOCAL_MODEL_COST_MAP=True
     volumes:
@@ -113,30 +170,199 @@ services:
         condition: service_healthy
       lobstergym-api:
         condition: service_healthy
-    command: >
-      bash -c "
-        echo '=== OpenClaw Default Gateway ===' &&
-        cat > /root/.openclaw/openclaw.json << 'CONF'
+    entrypoint: ["bash", "-lc"]
+    command:
+      - |
+        echo '=== OpenClaw Default Gateway ==='
+        cat > /root/.openclaw/openclaw.json << CONF
         {
-          \"agents\": {
-            \"defaults\": {
-              \"model\": {
-                \"primary\": \"openai/gpt-4o-mini\"
+          "gateway": {
+            "mode": "local",
+            "bind": "lan",
+            "auth": {
+              "mode": "token",
+              "token": "$${OPENCLAW_GATEWAY_TOKEN:-lobstergym-dev-token}"
+            },
+            "controlUi": {
+              "enabled": true,
+              "dangerouslyDisableDeviceAuth": true,
+              "allowInsecureAuth": true,
+              "allowedOrigins": [
+                "http://localhost:18789",
+                "http://127.0.0.1:18789",
+                "http://localhost:18790",
+                "http://127.0.0.1:18790"
+              ]
+            }
+          },
+          "agents": {
+            "defaults": {
+              "model": {
+                "primary": "openai/gpt-5-mini"
               }
             }
           },
-          \"browser\": {
-            \"enabled\": true,
-            \"headless\": true,
-            \"noSandbox\": true,
-            \"ssrfPolicy\": {
-              \"dangerouslyAllowPrivateNetwork\": true
+          "browser": {
+            "enabled": true,
+            "headless": true,
+            "noSandbox": true,
+            "ssrfPolicy": {
+              "dangerouslyAllowPrivateNetwork": true
             }
           }
         }
-      CONF
-        openclaw gateway --port 18789 --verbose
-      "
+        CONF
+        openclaw gateway --bind lan --port 18789 --verbose &
+        GATEWAY_PID=$$!
+        for i in $(seq 1 60); do
+          if python - <<'PY' >/dev/null 2>&1
+        import socket
+        s = socket.create_connection(("127.0.0.1", 18789), 2)
+        s.close()
+        PY
+          then
+            echo 'OPENCLAW_GATEWAY_READY profile=default port=18789'
+            break
+          fi
+          sleep 1
+        done
+        wait $$GATEWAY_PID
+
+  # -------------------------------------------------------------------
+  # Smoke check — ClawGraph profile
+  # -------------------------------------------------------------------
+  smoke-clawgraph:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+    environment:
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - OPENCLAW_GATEWAY_TOKEN=${OPENCLAW_GATEWAY_TOKEN:-lobstergym-dev-token}
+      - LITELLM_LOCAL_MODEL_COST_MAP=True
+    volumes:
+      - ..:/workspace:cached
+      - openclaw-clawgraph-home:/root/.openclaw
+    working_dir: /workspace
+    depends_on:
+      lobstergym-web:
+        condition: service_healthy
+      lobstergym-api:
+        condition: service_healthy
+    entrypoint: ["bash", "-c"]
+    command:
+      - |
+        echo '🦞 LobsterGym Smoke — ClawGraph Profile'
+        mkdir -p /root/.openclaw/workspace/skills
+        rm -rf /root/.openclaw/workspace/skills/clawgraph
+        cp -r /workspace/skills/clawgraph /root/.openclaw/workspace/skills/
+        pip install -e /workspace 2>/dev/null
+        cat > /root/.openclaw/openclaw.json << CONF
+        {
+          "gateway": {
+            "mode": "local",
+            "auth": {
+              "mode": "token",
+              "token": "$${OPENCLAW_GATEWAY_TOKEN:-lobstergym-dev-token}"
+            }
+          },
+          "agents": {
+            "defaults": {
+              "model": {
+                "primary": "openai/gpt-5-mini"
+              }
+            }
+          },
+          "browser": {
+            "enabled": true,
+            "headless": true,
+            "noSandbox": true,
+            "ssrfPolicy": {
+              "dangerouslyAllowPrivateNetwork": true
+            }
+          }
+        }
+        CONF
+        openclaw agent --local --to +15555550123 --json --message "If you are running inside this container, reply with exactly CONTAINER_SIGNAL_OK." > /tmp/openclaw-smoke.json
+        python - <<'PY'
+        import json
+        from pathlib import Path
+
+        data = json.loads(Path('/tmp/openclaw-smoke.json').read_text())
+        meta = data.get('meta', {}).get('agentMeta', {})
+        session_id = meta.get('sessionId')
+        model = meta.get('model')
+        if not session_id or not model:
+            raise SystemExit('OpenClaw smoke failed: missing sessionId/model in response')
+        payloads = data.get('payloads', [])
+        text = payloads[0].get('text', '') if payloads else ''
+        print(f'OPENCLAW_SMOKE_OK profile=clawgraph sessionId={session_id} model={model} text={text[:120]!r}')
+        PY
+
+  # -------------------------------------------------------------------
+  # Smoke check — Default profile
+  # -------------------------------------------------------------------
+  smoke-default:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+    environment:
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - OPENCLAW_GATEWAY_TOKEN=${OPENCLAW_GATEWAY_TOKEN:-lobstergym-dev-token}
+      - LITELLM_LOCAL_MODEL_COST_MAP=True
+    volumes:
+      - ..:/workspace:cached
+      - openclaw-default-home:/root/.openclaw
+    working_dir: /workspace
+    depends_on:
+      lobstergym-web:
+        condition: service_healthy
+      lobstergym-api:
+        condition: service_healthy
+    entrypoint: ["bash", "-c"]
+    command:
+      - |
+        echo '🦞 LobsterGym Smoke — Default Profile'
+        cat > /root/.openclaw/openclaw.json << CONF
+        {
+          "gateway": {
+            "mode": "local",
+            "auth": {
+              "mode": "token",
+              "token": "$${OPENCLAW_GATEWAY_TOKEN:-lobstergym-dev-token}"
+            }
+          },
+          "agents": {
+            "defaults": {
+              "model": {
+                "primary": "openai/gpt-5-mini"
+              }
+            }
+          },
+          "browser": {
+            "enabled": true,
+            "headless": true,
+            "noSandbox": true,
+            "ssrfPolicy": {
+              "dangerouslyAllowPrivateNetwork": true
+            }
+          }
+        }
+        CONF
+        openclaw agent --local --to +15555550123 --json --message "If you are running inside this container, reply with exactly CONTAINER_SIGNAL_OK." > /tmp/openclaw-smoke.json
+        python - <<'PY'
+        import json
+        from pathlib import Path
+
+        data = json.loads(Path('/tmp/openclaw-smoke.json').read_text())
+        meta = data.get('meta', {}).get('agentMeta', {})
+        session_id = meta.get('sessionId')
+        model = meta.get('model')
+        if not session_id or not model:
+            raise SystemExit('OpenClaw smoke failed: missing sessionId/model in response')
+        payloads = data.get('payloads', [])
+        text = payloads[0].get('text', '') if payloads else ''
+        print(f'OPENCLAW_SMOKE_OK profile=default sessionId={session_id} model={model} text={text[:120]!r}')
+        PY
 
   # -------------------------------------------------------------------
   # Eval runner — ClawGraph profile
@@ -147,6 +373,7 @@ services:
       dockerfile: .devcontainer/Dockerfile
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - OPENCLAW_GATEWAY_TOKEN=${OPENCLAW_GATEWAY_TOKEN:-lobstergym-dev-token}
       - LOBSTERGYM_WEB_BASE=http://lobstergym-web:8080
       - LOBSTERGYM_API_BASE=http://lobstergym-api:8090
       - LITELLM_LOCAL_MODEL_COST_MAP=True
@@ -168,12 +395,19 @@ services:
         cp -r /workspace/skills/clawgraph /root/.openclaw/workspace/skills/
         pip install -e /workspace 2>/dev/null
         pip install requests 2>/dev/null
-        cat > /root/.openclaw/openclaw.json << 'CONF'
+        cat > /root/.openclaw/openclaw.json << CONF
         {
+          "gateway": {
+            "mode": "local",
+            "auth": {
+              "mode": "token",
+              "token": "$${OPENCLAW_GATEWAY_TOKEN:-lobstergym-dev-token}"
+            }
+          },
           "agents": {
             "defaults": {
               "model": {
-                "primary": "openai/gpt-4o-mini"
+                "primary": "openai/gpt-5-mini"
               }
             }
           },
@@ -202,6 +436,7 @@ services:
       dockerfile: .devcontainer/Dockerfile
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - OPENCLAW_GATEWAY_TOKEN=${OPENCLAW_GATEWAY_TOKEN:-lobstergym-dev-token}
       - LOBSTERGYM_WEB_BASE=http://lobstergym-web:8080
       - LOBSTERGYM_API_BASE=http://lobstergym-api:8090
       - LITELLM_LOCAL_MODEL_COST_MAP=True
@@ -218,12 +453,19 @@ services:
     command:
       - |
         echo '🦞 LobsterGym Eval — Default Profile'
-        cat > /root/.openclaw/openclaw.json << 'CONF'
+        cat > /root/.openclaw/openclaw.json << CONF
         {
+          "gateway": {
+            "mode": "local",
+            "auth": {
+              "mode": "token",
+              "token": "$${OPENCLAW_GATEWAY_TOKEN:-lobstergym-dev-token}"
+            }
+          },
           "agents": {
             "defaults": {
               "model": {
-                "primary": "openai/gpt-4o-mini"
+                "primary": "openai/gpt-5-mini"
               }
             }
           },

--- a/scripts/openclaw-chat.ps1
+++ b/scripts/openclaw-chat.ps1
@@ -1,0 +1,134 @@
+param(
+    [Parameter(Mandatory = $true, Position = 0)]
+    [string]$Message,
+
+    [string]$Service = "openclaw-default",
+
+    [string]$ComposeFile = "lobstergym/docker-compose.yml",
+
+    [string]$To = "+15555550123",
+
+    [switch]$RawJson
+)
+
+$ErrorActionPreference = "Stop"
+
+function Quote-Arg {
+    param([string]$Value)
+
+    if ($null -eq $Value) {
+        return '""'
+    }
+
+    if ($Value -match '[\s"]') {
+        return '"' + ($Value -replace '"', '\"') + '"'
+    }
+
+    return $Value
+}
+
+if (-not (Test-Path -LiteralPath $ComposeFile)) {
+    throw "Compose file not found: $ComposeFile"
+}
+
+$runningServices = & docker compose -f $ComposeFile ps --services --status running
+if ($LASTEXITCODE -ne 0) {
+    throw "Failed to query Docker Compose services."
+}
+
+$runningServiceList = @($runningServices | Where-Object { $_ -and $_.Trim() })
+if ($Service -notin $runningServiceList) {
+    throw "Service '$Service' is not running. Start it with: docker compose -f $ComposeFile up -d $Service"
+}
+
+try {
+    $stdoutFile = [System.IO.Path]::GetTempFileName()
+    $stderrFile = [System.IO.Path]::GetTempFileName()
+
+    $dockerCommand = (Get-Command docker).Source
+    $argumentString = @(
+        'compose',
+        '-f', (Quote-Arg $ComposeFile),
+        'exec',
+        '-T',
+        (Quote-Arg $Service),
+        'openclaw',
+        'agent',
+        '--local',
+        '--to', (Quote-Arg $To),
+        '--json',
+        '--message', (Quote-Arg $Message)
+    ) -join ' '
+
+    $process = Start-Process -FilePath $dockerCommand -ArgumentList $argumentString -Wait -PassThru -NoNewWindow -RedirectStandardOutput $stdoutFile -RedirectStandardError $stderrFile
+    $exitCode = $process.ExitCode
+
+    $raw = if (Test-Path -LiteralPath $stdoutFile) {
+        Get-Content -LiteralPath $stdoutFile -Raw
+    }
+    else {
+        ""
+    }
+
+    $stderr = if (Test-Path -LiteralPath $stderrFile) {
+        Get-Content -LiteralPath $stderrFile -Raw
+    }
+    else {
+        ""
+    }
+
+    if ($exitCode -ne 0) {
+        throw "OpenClaw command failed.`n$stderr`n$raw"
+    }
+
+    if ([string]::IsNullOrWhiteSpace($raw)) {
+        throw "OpenClaw returned an empty response.`n$stderr"
+    }
+
+    $jsonStart = $raw.IndexOf('{')
+    if ($jsonStart -lt 0) {
+        throw "Could not find JSON in OpenClaw output.`n$raw"
+    }
+
+    $json = $raw.Substring($jsonStart).Trim()
+
+    if ($RawJson) {
+        $json
+        return
+    }
+
+    $data = $json | ConvertFrom-Json
+    $agentMeta = $data.meta.agentMeta
+    $payloadText = $null
+
+    if ($data.payloads -and $data.payloads.Count -gt 0) {
+        $payloadText = $data.payloads[0].text
+    }
+
+    "service:    $Service"
+    if ($agentMeta.sessionId) {
+        "sessionId:  $($agentMeta.sessionId)"
+    }
+    if ($agentMeta.model) {
+        "model:      $($agentMeta.model)"
+    }
+    if ($agentMeta.provider) {
+        "provider:   $($agentMeta.provider)"
+    }
+
+    if ($payloadText) {
+        ""
+        $payloadText
+    }
+    else {
+        $json
+    }
+}
+finally {
+    if ($stdoutFile) {
+        Remove-Item -LiteralPath $stdoutFile -ErrorAction SilentlyContinue
+    }
+    if ($stderrFile) {
+        Remove-Item -LiteralPath $stderrFile -ErrorAction SilentlyContinue
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the lobstergym-eval CI pipeline so OpenClaw gateways start correctly and the eval runner can reach both the mock web/API services and the LLM.

## Changes

### API route fixes
- Reorder FastAPI routes in \lobstergym/api/app.py\: static routes (\/weather/state\, \/notes/state\) before dynamic (\/weather/{city}\, \/notes/{note_id}\) to prevent 404 shadowing

### OpenClaw gateway config (\lobstergym/docker-compose.yml\)
- Add \gateway.mode=local\ (required for gateway to start)
- Add \gateway.bind=lan\ (listen on all interfaces inside container)
- Add stable auth token via \OPENCLAW_GATEWAY_TOKEN\ env var (default: \lobstergym-dev-token\)
- Add \controlUi.allowedOrigins\ for host ports 18789/18790
- Add \controlUi.dangerouslyDisableDeviceAuth\ + \llowInsecureAuth\ for dev browser access
- Add browser config (\headless\, \
oSandbox\, \ssrfPolicy.dangerouslyAllowPrivateNetwork\)
- Add healthchecks with \start_period: 30s\ for gateway startup time
- Add smoke-check services (\smoke-clawgraph\, \smoke-default\)
- Switch model to \openai/gpt-5-mini\
- Gateway startup: background process + port polling + READY banner

### CI workflow (\.github/workflows/test.yml\)
- Add smoke-check steps before eval runs
- Make eval steps non-blocking (\continue-on-error: true\)

### Devcontainer (\.devcontainer/docker-compose.test.yml\)
- Add \gateway.mode=local\, \gateway.bind=lan\, \controlUi\ config
- Switch model to \openai/gpt-5-mini\

### New: chat helper script
- \scripts/openclaw-chat.ps1\ — PowerShell 5.1 compatible helper to chat with OpenClaw from local terminal

## Testing

- Verified gateway starts and reaches READY state in container
- Verified API responds: \gpt-5-mini\ returns \STATUS 200\ + \Hello!\
- Verified Control UI loads at \http://127.0.0.1:18790/?token=lobstergym-dev-token\
- \docker compose config -q\ passes