### PR TITLE
fix: separate eval/smoke volumes and use gpt-5.4 model

### DIFF
--- a/lobstergym/docker-compose.yml
+++ b/lobstergym/docker-compose.yml
@@ -105,7 +105,7 @@ services:
           "agents": {
             "defaults": {
               "model": {
-                "primary": "openai/gpt-5-mini"
+                "primary": "openai/gpt-5.4"
               }
             }
           },
@@ -198,7 +198,7 @@ services:
           "agents": {
             "defaults": {
               "model": {
-                "primary": "openai/gpt-5-mini"
+                "primary": "openai/gpt-5.4"
               }
             }
           },
@@ -241,7 +241,7 @@ services:
       - LITELLM_LOCAL_MODEL_COST_MAP=True
     volumes:
       - ..:/workspace:cached
-      - openclaw-clawgraph-home:/root/.openclaw
+      - smoke-clawgraph-home:/root/.openclaw
     working_dir: /workspace
     depends_on:
       lobstergym-web:
@@ -268,7 +268,7 @@ services:
           "agents": {
             "defaults": {
               "model": {
-                "primary": "openai/gpt-5-mini"
+                "primary": "openai/gpt-5.4"
               }
             }
           },
@@ -319,7 +319,7 @@ services:
       - LITELLM_LOCAL_MODEL_COST_MAP=True
     volumes:
       - ..:/workspace:cached
-      - openclaw-default-home:/root/.openclaw
+      - smoke-default-home:/root/.openclaw
     working_dir: /workspace
     depends_on:
       lobstergym-web:
@@ -342,7 +342,7 @@ services:
           "agents": {
             "defaults": {
               "model": {
-                "primary": "openai/gpt-5-mini"
+                "primary": "openai/gpt-5.4"
               }
             }
           },
@@ -398,7 +398,7 @@ services:
       - LITELLM_LOCAL_MODEL_COST_MAP=True
     volumes:
       - ..:/workspace:cached
-      - openclaw-clawgraph-home:/root/.openclaw
+      - eval-clawgraph-home:/root/.openclaw
     working_dir: /workspace
     depends_on:
       openclaw-clawgraph:
@@ -415,7 +415,11 @@ services:
         GATEWAY_IP=$$(getent hosts $${OPENCLAW_GATEWAY_HOST} | awk '{print $$1}')
         export OPENCLAW_GATEWAY_URL="ws://$${GATEWAY_IP}:18789"
         echo "Gateway URL: $$OPENCLAW_GATEWAY_URL"
-        # Overwrite config to remove mode=local (volume has gateway's local config)
+        # Install ClawGraph skill + package for embedded fallback
+        mkdir -p /root/.openclaw/workspace/skills
+        cp -r /workspace/skills/clawgraph /root/.openclaw/workspace/skills/
+        pip install -e /workspace 2>/dev/null
+        pip install requests 2>/dev/null
         cat > /root/.openclaw/openclaw.json << CONF
         {
           "gateway": {
@@ -423,11 +427,24 @@ services:
               "mode": "token",
               "token": "$${OPENCLAW_GATEWAY_TOKEN:-lobstergym-dev-token}"
             }
+          },
+          "agents": {
+            "defaults": {
+              "model": {
+                "primary": "openai/gpt-5.4"
+              }
+            }
+          },
+          "browser": {
+            "enabled": true,
+            "headless": true,
+            "noSandbox": true,
+            "ssrfPolicy": {
+              "dangerouslyAllowPrivateNetwork": true
+            }
           }
         }
         CONF
-        pip install -e /workspace 2>/dev/null
-        pip install requests 2>/dev/null
         python -m lobstergym.eval.runner \
           --profile clawgraph \
           --output /workspace/lobstergym/reports/eval-clawgraph.json
@@ -452,7 +469,7 @@ services:
       - LITELLM_LOCAL_MODEL_COST_MAP=True
     volumes:
       - ..:/workspace:cached
-      - openclaw-default-home:/root/.openclaw
+      - eval-default-home:/root/.openclaw
     working_dir: /workspace
     depends_on:
       openclaw-default:
@@ -469,7 +486,8 @@ services:
         GATEWAY_IP=$$(getent hosts $${OPENCLAW_GATEWAY_HOST} | awk '{print $$1}')
         export OPENCLAW_GATEWAY_URL="ws://$${GATEWAY_IP}:18789"
         echo "Gateway URL: $$OPENCLAW_GATEWAY_URL"
-        # Overwrite config to remove mode=local (volume has gateway's local config)
+        pip install -e /workspace 2>/dev/null
+        pip install requests 2>/dev/null
         cat > /root/.openclaw/openclaw.json << CONF
         {
           "gateway": {
@@ -477,11 +495,24 @@ services:
               "mode": "token",
               "token": "$${OPENCLAW_GATEWAY_TOKEN:-lobstergym-dev-token}"
             }
+          },
+          "agents": {
+            "defaults": {
+              "model": {
+                "primary": "openai/gpt-5.4"
+              }
+            }
+          },
+          "browser": {
+            "enabled": true,
+            "headless": true,
+            "noSandbox": true,
+            "ssrfPolicy": {
+              "dangerouslyAllowPrivateNetwork": true
+            }
           }
         }
         CONF
-        pip install -e /workspace 2>/dev/null
-        pip install requests 2>/dev/null
         python -m lobstergym.eval.runner \
           --profile default \
           --output /workspace/lobstergym/reports/eval-default.json
@@ -491,3 +522,7 @@ services:
 volumes:
   openclaw-clawgraph-home:
   openclaw-default-home:
+  smoke-clawgraph-home:
+  smoke-default-home:
+  eval-clawgraph-home:
+  eval-default-home:


### PR DESCRIPTION
## Problem

The eval pipeline was failing with all 12 tasks at 0% because:

1. **Shared Docker volumes**: Eval containers shared \/root/.openclaw\ volumes with their gateway containers. When the eval container wrote its own \openclaw.json\, it overwrote the running gateway's config — removing \mode: local\ and \ind: lan\ — causing the gateway to drop WebSocket connections (1006 abnormal closure).

2. **Anthropic fallback**: After the gateway connection failed, openclaw fell back to embedded mode and defaulted to Anthropic (no API key configured) instead of OpenAI.

3. **Wrong model**: All configs used \gpt-5-mini\ instead of the intended \gpt-5.4\ frontier model.

## Fix

- **6 isolated Docker volumes** — each container (2 gateways, 2 smokes, 2 evals) gets its own volume so config writes never interfere with running gateway processes
- **Model updated to \openai/gpt-5.4\** across all 6 service configs
- **Browser config + skill copy** added to eval containers for robust embedded-mode fallback
- Eval containers now install ClawGraph skills and write complete configs (gateway auth, model, browser) before running the eval runner