### PR TITLE
feat: enable Sigstore attestations on PyPI publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   id-token: write
   contents: read
+  attestations: write
 
 jobs:
   publish:
@@ -28,3 +29,5 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          attestations: true


### PR DESCRIPTION
Adds Sigstore provenance attestations to the publish workflow. After merge, PyPI will show a verified provenance badge linking each release back to the exact GitHub Actions build that produced it.

Changes to \.github/workflows/publish.yml\:
- Added \ttestations: write\ permission
- Added \ttestations: true\ to the publish step