### PR TITLE
fix: skip editable install in pip-audit CI workflow

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -35,7 +35,7 @@ jobs:
         run: pip install -e .
 
       - name: pip-audit — check for known vulnerabilities
-        run: pip-audit --strict --desc
+        run: pip-audit --strict --desc --skip-editable
 
       - name: Alert on failure
         if: failure()


### PR DESCRIPTION
## Problem

The daily pip-audit workflow fails because clawgraph is installed in editable mode (pip install -e .), and pip-audit cannot resolve version metadata for editable packages.

## Fix

Add --skip-editable to the pip-audit command so it only audits real published dependencies (openai, kuzu, typer, etc.) and skips the local editable install.

## Changes

- .github/workflows/dependency-audit.yml: pip-audit --strict --desc --skip-editable