### PR TITLE
fix: use non-editable install in pip-audit CI workflow

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -32,10 +32,10 @@ jobs:
         run: pip install pip-audit==2.10.0
 
       - name: Install project dependencies
-        run: pip install -e .
+        run: pip install .
 
       - name: pip-audit — check for known vulnerabilities
-        run: pip-audit --strict --desc --skip-editable
+        run: pip-audit --strict --desc
 
       - name: Alert on failure
         if: failure()


### PR DESCRIPTION
Follows up on #33. pip-audit still errors on editable installs even with --skip-editable.

Fix: change pip install -e . to pip install . and drop --skip-editable. No editable package, no error.