### PR TITLE
security: harden code against injection, path traversal, and info leaks

### DIFF
--- a/src/clawgraph/config.py
+++ b/src/clawgraph/config.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -46,14 +48,26 @@ def load_config() -> dict[str, Any]:
 def save_config(config: dict[str, Any]) -> None:
     """Save configuration to ~/.clawgraph/config.yaml.
 
+    On Unix-like systems, sets directory permissions to 0o700 and
+    file permissions to 0o600 to prevent other users reading config
+    (which may contain API keys).
+
     Args:
         config: Configuration dictionary to save.
     """
     config_path = get_config_path()
     config_path.parent.mkdir(parents=True, exist_ok=True)
 
+    # Restrict directory permissions on Unix
+    if sys.platform != "win32":
+        os.chmod(config_path.parent, 0o700)
+
     with open(config_path, "w") as f:
         yaml.dump(config, f, default_flow_style=False, sort_keys=False)
+
+    # Restrict file permissions on Unix
+    if sys.platform != "win32":
+        os.chmod(config_path, 0o600)
 
 
 def get_config_value(key: str) -> Any:

--- a/src/clawgraph/cypher.py
+++ b/src/clawgraph/cypher.py
@@ -4,11 +4,19 @@ from __future__ import annotations
 
 import re
 
+# Maximum query length (chars) to prevent abuse
+_MAX_QUERY_LENGTH = 5000
+
 # Patterns that should never appear in generated Cypher
 _DANGEROUS_PATTERNS: list[tuple[str, str]] = [
     (r"\bDROP\b", "DROP statements are not allowed"),
     (r"\bDELETE\s+DATABASE\b", "Database deletion is not allowed"),
     (r"\bCALL\s+dbms\b", "DBMS calls are not allowed"),
+    (r"\bLOAD\b", "LOAD statements are not allowed"),
+    (r"\bCOPY\b", "COPY statements are not allowed"),
+    (r"\bEXPORT\b", "EXPORT statements are not allowed"),
+    (r"//", "Single-line comments are not allowed"),
+    (r"/\*", "Block comments are not allowed"),
 ]
 
 # Basic structural patterns that valid Cypher should match
@@ -38,6 +46,14 @@ def validate_cypher(cypher: str) -> CypherValidationResult:
         return CypherValidationResult(is_valid=False, errors=["Empty query"])
 
     cleaned = cypher.strip()
+
+    # Check query length
+    if len(cleaned) > _MAX_QUERY_LENGTH:
+        errors.append(f"Query exceeds maximum length of {_MAX_QUERY_LENGTH} characters")
+
+    # Check for embedded newlines/carriage returns that could bypass pattern matching
+    if "\r" in cleaned:
+        errors.append("Carriage returns are not allowed in queries")
 
     # Check for dangerous patterns
     for pattern, message in _DANGEROUS_PATTERNS:

--- a/src/clawgraph/db.py
+++ b/src/clawgraph/db.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import logging
 import tarfile
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 import kuzu
+
+logger = logging.getLogger(__name__)
 
 
 class GraphDB:
@@ -58,7 +61,8 @@ class GraphDB:
                 rows.append(dict(zip(result.get_column_names(), row)))
             return rows
         except Exception as e:
-            raise DatabaseError(f"Cypher execution failed: {e}") from e
+            logger.debug("Cypher execution failed: %s", e)
+            raise DatabaseError("Cypher execution failed") from e
 
     def get_tables(self) -> list[dict[str, Any]]:
         """Get all tables in the database."""
@@ -233,6 +237,13 @@ class GraphDB:
                 if not members:
                     raise DatabaseError("Empty snapshot archive")
                 top_dir = members[0].split("/")[0]
+                # Validate all paths to prevent path traversal attacks
+                for name in members:
+                    member_path = (target / name).resolve()
+                    if not str(member_path).startswith(str(target.resolve())):
+                        raise DatabaseError(
+                            f"Snapshot contains path traversal: {name}"
+                        )
                 tar.extractall(str(target))
         except tarfile.TarError as e:
             raise DatabaseError(f"Failed to extract snapshot: {e}") from e
@@ -255,8 +266,8 @@ class GraphDB:
         for stmt in migrations:
             try:
                 self._conn.execute(stmt)
-            except Exception:
-                pass  # Column likely already exists
+            except RuntimeError:
+                pass  # Column already exists
 
     @staticmethod
     def now_iso() -> str:

--- a/src/clawgraph/llm.py
+++ b/src/clawgraph/llm.py
@@ -15,13 +15,20 @@ from openai import OpenAI, OpenAIError
 
 from clawgraph.config import load_config
 
+# Maximum length for entity/relationship names to prevent abuse
+_MAX_NAME_LENGTH = 500
+
+# Pattern for safe entity names (alphanumeric, spaces, hyphens, underscores, dots)
+_SAFE_NAME_PATTERN = re.compile(r"^[\w\s.\-']+$", re.UNICODE)
+
 
 def _load_dotenv() -> None:
-    """Load .env file from cwd if present.
+    """Load .env file from ~/.clawgraph/.env if present.
 
-    .env values OVERRIDE system env vars so the project config wins.
+    Uses setdefault so existing env vars are NOT overridden.
+    This prevents a malicious .env in CWD from hijacking API keys.
     """
-    env_path = os.path.join(os.getcwd(), ".env")
+    env_path = os.path.join(os.path.expanduser("~"), ".clawgraph", ".env")
     if os.path.exists(env_path):
         with open(env_path) as f:
             for line in f:
@@ -32,7 +39,7 @@ def _load_dotenv() -> None:
                 key = key.strip()
                 val = val.strip().strip("'\"")
                 if key and val:
-                    os.environ[key] = val
+                    os.environ.setdefault(key, val)
 
 
 _load_dotenv()
@@ -255,11 +262,35 @@ def infer_ontology_batch(
         raise LLMError(f"Failed to parse batch ontology response: {e}\nRaw: {cleaned}") from e
 
 
+def _validate_name(value: str, field: str) -> str:
+    """Validate and sanitize an entity/relationship name.
+
+    Args:
+        value: The name string to validate.
+        field: Field label for error messages.
+
+    Returns:
+        The sanitized name.
+
+    Raises:
+        LLMError: If the name is empty, too long, or contains unsafe chars.
+    """
+    if not value or not value.strip():
+        raise LLMError(f"Empty {field} name from LLM output")
+    value = value.strip()
+    if len(value) > _MAX_NAME_LENGTH:
+        raise LLMError(f"{field} name exceeds {_MAX_NAME_LENGTH} chars")
+    if not _SAFE_NAME_PATTERN.match(value):
+        raise LLMError(f"Unsafe characters in {field} name: {value!r}")
+    return value
+
+
 def build_merge_cypher(entities: list[dict[str, str]], relationships: list[dict[str, str]]) -> str:
     """Build MERGE Cypher statements from extracted entities and relationships.
 
     This generates Kùzu-compatible MERGE queries using the generic
-    Entity/Relates schema.
+    Entity/Relates schema. All names are validated for safe characters
+    and length before being interpolated into queries.
 
     Args:
         entities: List of dicts with 'name' and 'label'.
@@ -267,6 +298,9 @@ def build_merge_cypher(entities: list[dict[str, str]], relationships: list[dict[
 
     Returns:
         Multi-line Cypher string with MERGE statements.
+
+    Raises:
+        LLMError: If any entity/relationship name is invalid.
     """
     from clawgraph.db import GraphDB
 
@@ -274,17 +308,22 @@ def build_merge_cypher(entities: list[dict[str, str]], relationships: list[dict[
     lines: list[str] = []
 
     for entity in entities:
-        name = entity["name"].replace("'", "\\'")
-        label = entity.get("label", "Unknown").replace("'", "\\'")
+        name = _validate_name(entity["name"], "entity")
+        label = _validate_name(entity.get("label", "Unknown"), "label")
+        name = name.replace("'", "\\'")
+        label = label.replace("'", "\\'")
         lines.append(
             f"MERGE (e:Entity {{name: '{name}'}}) "
             f"SET e.label = '{label}', e.updated_at = '{now}';"
         )
 
     for rel in relationships:
-        from_name = rel["from"].replace("'", "\\'")
-        to_name = rel["to"].replace("'", "\\'")
-        rel_type = rel.get("type", "RELATED_TO").replace("'", "\\'")
+        from_name = _validate_name(rel["from"], "relationship source")
+        to_name = _validate_name(rel["to"], "relationship target")
+        rel_type = _validate_name(rel.get("type", "RELATED_TO"), "relationship type")
+        from_name = from_name.replace("'", "\\'")
+        to_name = to_name.replace("'", "\\'")
+        rel_type = rel_type.replace("'", "\\'")
         lines.append(
             f"MATCH (a:Entity {{name: '{from_name}'}}), (b:Entity {{name: '{to_name}'}}) "
             f"MERGE (a)-[r:Relates {{type: '{rel_type}'}}]->(b);"

--- a/tests/test_cypher.py
+++ b/tests/test_cypher.py
@@ -49,6 +49,46 @@ class TestSanitizeCypher:
     def test_removes_trailing_semicolon(self) -> None:
         assert sanitize_cypher("MATCH (n) RETURN n;") == "MATCH (n) RETURN n"
 
+
+class TestCypherSecurityHardening:
+    """Security-focused tests for Cypher validation."""
+
+    def test_load_blocked(self) -> None:
+        result = validate_cypher("LOAD CSV FROM 'file:///etc/passwd'")
+        assert not result.is_valid
+        assert any("LOAD" in e for e in result.errors)
+
+    def test_copy_blocked(self) -> None:
+        result = validate_cypher("COPY Entity FROM 'data.csv'")
+        assert not result.is_valid
+        assert any("COPY" in e for e in result.errors)
+
+    def test_export_blocked(self) -> None:
+        result = validate_cypher("EXPORT DATABASE 'backup'")
+        assert not result.is_valid
+        assert any("EXPORT" in e for e in result.errors)
+
+    def test_single_line_comment_blocked(self) -> None:
+        result = validate_cypher("MATCH (n) RETURN n // hidden DROP TABLE")
+        assert not result.is_valid
+        assert any("comment" in e.lower() for e in result.errors)
+
+    def test_block_comment_blocked(self) -> None:
+        result = validate_cypher("MATCH (n) /* DROP TABLE */ RETURN n")
+        assert not result.is_valid
+        assert any("comment" in e.lower() for e in result.errors)
+
+    def test_carriage_return_blocked(self) -> None:
+        result = validate_cypher("MATCH (n)\rRETURN n")
+        assert not result.is_valid
+        assert any("Carriage" in e for e in result.errors)
+
+    def test_query_length_limit(self) -> None:
+        long_query = "MATCH (n) RETURN n " + "a" * 5000
+        result = validate_cypher(long_query)
+        assert not result.is_valid
+        assert any("length" in e for e in result.errors)
+
     def test_handles_plain_fences(self) -> None:
         raw = "```\nMATCH (n) RETURN n\n```"
         assert sanitize_cypher(raw) == "MATCH (n) RETURN n"

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,5 +1,6 @@
 """Tests for LLM integration layer."""
 
+import pytest
 from unittest.mock import MagicMock, patch
 
 from clawgraph.llm import LLMError, build_merge_cypher
@@ -49,6 +50,48 @@ class TestBuildMergeCypher:
         assert "updated_at" in cypher
         # Timestamp should be ISO format with T separator
         assert "T" in cypher
+
+
+class TestEntityNameValidation:
+    """Security tests for entity name validation in build_merge_cypher."""
+
+    def test_rejects_empty_name(self) -> None:
+        with pytest.raises(LLMError, match="Empty entity name"):
+            build_merge_cypher([{"name": "", "label": "Person"}], [])
+
+    def test_rejects_whitespace_only_name(self) -> None:
+        with pytest.raises(LLMError, match="Empty entity name"):
+            build_merge_cypher([{"name": "   ", "label": "Person"}], [])
+
+    def test_rejects_too_long_name(self) -> None:
+        with pytest.raises(LLMError, match="exceeds"):
+            build_merge_cypher([{"name": "A" * 501, "label": "Person"}], [])
+
+    def test_rejects_injection_characters(self) -> None:
+        with pytest.raises(LLMError, match="Unsafe characters"):
+            build_merge_cypher([{"name": "John; DROP TABLE", "label": "Person"}], [])
+
+    def test_rejects_curly_braces(self) -> None:
+        with pytest.raises(LLMError, match="Unsafe characters"):
+            build_merge_cypher([{"name": "John{}", "label": "Person"}], [])
+
+    def test_allows_unicode_names(self) -> None:
+        cypher = build_merge_cypher([{"name": "André", "label": "Person"}], [])
+        assert "André" in cypher
+
+    def test_allows_hyphenated_names(self) -> None:
+        cypher = build_merge_cypher([{"name": "Mary-Jane", "label": "Person"}], [])
+        assert "Mary-Jane" in cypher
+
+    def test_allows_dotted_names(self) -> None:
+        cypher = build_merge_cypher([{"name": "Dr. Smith", "label": "Person"}], [])
+        assert "Dr. Smith" in cypher
+
+    def test_rejects_empty_relationship_source(self) -> None:
+        entities = [{"name": "John", "label": "Person"}]
+        rels = [{"from": "", "to": "John", "type": "KNOWS"}]
+        with pytest.raises(LLMError, match="Empty relationship source"):
+            build_merge_cypher(entities, rels)
 
 
 class TestGenerateCypher:


### PR DESCRIPTION
## Security Hardening

Addresses all 5 code hardening items from the security audit (secure.md).

### Changes

**1. [HIGH] .env loader hijack (llm.py)**
- Load from ~/.clawgraph/.env instead of CWD
- Use os.environ.setdefault() so existing env vars cannot be overridden
- Prevents malicious .env planted in working directory from redirecting LLM calls

**2. [MEDIUM] Cypher validation gaps (cypher.py)**
- Block LOAD, COPY, EXPORT (filesystem access)
- Block comments (// and /* */) -- can bypass pattern matching
- Add query length limit (5000 chars)
- Reject carriage returns (multi-line injection vector)

**3. [MEDIUM] Entity name injection (llm.py)**
- Validate names against safe character pattern [\\w\\s.\\-']+
- Max length check (500 chars)
- Reject empty/whitespace-only names
- Applied to all entity names, labels, and relationship types before Cypher interpolation

**4. [LOW] DB error message leakage (db.py)**
- Log full error at DEBUG level
- Return generic 'Cypher execution failed' to callers
- Narrow _migrate_timestamps to catch RuntimeError only (not all exceptions)

**5. [LOW] Config file permissions (config.py)**
- Set 0o700 on ~/.clawgraph/ directory
- Set 0o600 on config.yaml file
- Unix only (skipped on Windows)

**Bonus: Tarfile path traversal (db.py)**
- Validate all archive member paths in load_snapshot() before extraction
- Prevents zip-slip / path traversal attacks via crafted snapshot archives

### Tests

- 16 new security-focused tests added
- Total: 98 tests, all passing
- ruff + mypy clean