### PR TITLE
feat: codebase quality improvements and CLI tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ ClawGraph converts natural language into graph memory. Tell it facts, it stores 
 - **Automatic ontology** — the LLM infers and maintains your graph schema
 - **Python API** — `from clawgraph import Memory` for use in agentic loops
 - **Batch mode** — process multiple facts in a single LLM call
-- **Provider-agnostic** — works with any LLM via LiteLLM (OpenAI, Anthropic, etc.)
+- **Provider-agnostic** — works with any OpenAI-compatible API (OpenAI, Azure, local LLMs via base_url)
 - **Idempotent** — adding the same fact twice won't create duplicates
 
 ## Installation
@@ -137,7 +137,7 @@ ClawGraph uses a **generic schema** — all entities are stored as `Entity(name,
 | Component | Library | Why |
 |-----------|---------|-----|
 | CLI | [Typer](https://typer.tiangolo.com/) | Type-hint driven, minimal boilerplate |
-| LLM | [LiteLLM](https://docs.litellm.ai/) | Any provider via one interface |
+| LLM | [OpenAI SDK](https://github.com/openai/openai-python) | Direct, supports any OpenAI-compatible endpoint via base_url |
 | Graph DB | [Kùzu](https://kuzudb.com/) | Embedded, no server, native Cypher |
 | Output | [Rich](https://rich.readthedocs.io/) | Tables, panels, colors |
 
@@ -161,13 +161,13 @@ ClawGraph needs an API key from your LLM provider. There are three ways to provi
 
 **1. Project `.env` file (recommended)**
 
-Create a `.env` file in your working directory:
+Create a `.env` file at `~/.clawgraph/.env`:
 
 ```bash
 OPENAI_API_KEY=sk-proj-...
 ```
 
-ClawGraph auto-loads `.env` from the current directory. This file takes precedence over system environment variables.
+ClawGraph auto-loads this file on startup. Existing environment variables take precedence (the `.env` won't override them).
 
 **2. Environment variable**
 

--- a/src/clawgraph/cli.py
+++ b/src/clawgraph/cli.py
@@ -13,6 +13,7 @@ from rich.panel import Panel
 from rich.table import Table
 
 from clawgraph import __version__
+from clawgraph.memory import Memory
 
 app = typer.Typer(
     name="clawgraph",
@@ -136,8 +137,8 @@ def add(
     for entity in entities:
         ontology.add_node_label(entity.get("label", "Unknown"), {"name": "STRING"})
     for rel in relationships:
-        from_label = _find_label(rel.get("from", ""), entities)
-        to_label = _find_label(rel.get("to", ""), entities)
+        from_label = Memory._find_label(rel.get("from", ""), entities)
+        to_label = Memory._find_label(rel.get("to", ""), entities)
         ontology.add_relationship_type(rel.get("type", "RELATED_TO"), from_label, to_label)
 
     result = {
@@ -153,16 +154,8 @@ def add(
             console.print("[bold green]Done![/bold green]")
         else:
             console.print(f"[bold yellow]Completed with {len(errors)} error(s)[/bold yellow]")
-    else:
-        _output(result, output)
 
-
-def _find_label(name: str, entities: list[dict[str, str]]) -> str:
-    """Find the label for an entity by name."""
-    for entity in entities:
-        if entity.get("name") == name:
-            return entity.get("label", "Unknown")
-    return "Unknown"
+    _output(result, output)
 
 
 @app.command("add-batch")
@@ -176,14 +169,15 @@ def add_batch(
     ),
 ) -> None:
     """Add multiple facts in a single LLM call (faster for batch operations)."""
-    from clawgraph.memory import Memory
+    from clawgraph.db import DatabaseError
+    from clawgraph.llm import LLMError
 
     console.print(f"[bold blue]Batch adding {len(statements)} statements...[/bold blue]")
 
     try:
         mem = Memory(model=model)
         result = mem.add_batch(statements)
-    except Exception as e:
+    except (LLMError, DatabaseError) as e:
         console.print(f"[bold red]Error:[/bold red] {e}")
         raise typer.Exit(1)
 

--- a/src/clawgraph/memory.py
+++ b/src/clawgraph/memory.py
@@ -203,6 +203,14 @@ class Memory:
         """Close the database connection."""
         self._db.close()
 
+    def __enter__(self) -> Memory:
+        """Enter context manager."""
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        """Exit context manager and close database."""
+        self.close()
+
     def save_snapshot(self, output_path: str | Path) -> Path:
         """Save a snapshot of the database as a .tar.gz archive.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,160 @@
+"""Tests for CLI commands."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from clawgraph.cli import app
+
+runner = CliRunner()
+
+
+def _extract_json(output: str) -> dict:
+    """Extract JSON object from mixed CLI output."""
+    # Look for pretty-printed JSON starting with { on its own line
+    lines = output.split("\n")
+    json_start = None
+    for i, line in enumerate(lines):
+        if line.strip() == "{":
+            json_start = i
+            break
+    assert json_start is not None, f"No JSON found in output: {output}"
+    json_str = "\n".join(lines[json_start:])
+    return json.loads(json_str)
+
+
+class TestVersion:
+    """Tests for version output."""
+
+    def test_version_flag(self) -> None:
+        result = runner.invoke(app, ["--version"])
+        assert result.exit_code == 0
+        assert "clawgraph" in result.output
+
+    def test_short_version_flag(self) -> None:
+        result = runner.invoke(app, ["-v"])
+        assert result.exit_code == 0
+        assert "clawgraph" in result.output
+
+
+class TestConfig:
+    """Tests for config command."""
+
+    def test_show_all_config(self) -> None:
+        result = runner.invoke(app, ["config"])
+        assert result.exit_code == 0
+        assert "llm" in result.output
+
+    def test_get_config_value(self) -> None:
+        result = runner.invoke(app, ["config", "llm.model"])
+        assert result.exit_code == 0
+        assert result.output.strip() != ""
+
+    def test_get_missing_key(self) -> None:
+        result = runner.invoke(app, ["config", "nonexistent.key"])
+        assert result.exit_code == 0
+        assert "not set" in result.output
+
+
+class TestOntology:
+    """Tests for ontology command."""
+
+    def test_show_ontology(self) -> None:
+        result = runner.invoke(app, ["ontology"])
+        assert result.exit_code == 0
+
+    def test_ontology_json_output(self) -> None:
+        result = runner.invoke(app, ["ontology", "--output", "json"])
+        assert result.exit_code == 0
+
+
+class TestExport:
+    """Tests for export command."""
+
+    def test_export_stdout(self) -> None:
+        result = runner.invoke(app, ["export"])
+        assert result.exit_code == 0
+
+    def test_export_json(self, tmp_path: object) -> None:
+        out_file = str(tmp_path) + "/export.json"  # type: ignore[operator]
+        result = runner.invoke(app, ["export", out_file])
+        assert result.exit_code == 0
+
+
+class TestAdd:
+    """Tests for add command with mocked LLM."""
+
+    @patch("clawgraph.llm.infer_ontology")
+    @patch("clawgraph.llm.build_merge_cypher")
+    @patch("clawgraph.db.GraphDB")
+    def test_add_json_output(
+        self,
+        mock_db_cls: MagicMock,
+        mock_build: MagicMock,
+        mock_infer: MagicMock,
+    ) -> None:
+        mock_infer.return_value = {
+            "entities": [{"name": "John", "label": "Person"}],
+            "relationships": [],
+        }
+        mock_build.return_value = "MERGE (e:Entity {name: 'John'}) SET e.label = 'Person'"
+        mock_db = MagicMock()
+        mock_db_cls.return_value = mock_db
+
+        result = runner.invoke(app, ["add", "John is a person", "--output", "json"])
+        assert result.exit_code == 0
+        parsed = _extract_json(result.output)
+        assert parsed["status"] == "ok"
+        assert len(parsed["entities"]) == 1
+
+    @patch("clawgraph.llm.infer_ontology")
+    def test_add_llm_error(self, mock_infer: MagicMock) -> None:
+        from clawgraph.llm import LLMError
+
+        mock_infer.side_effect = LLMError("API failed")
+        result = runner.invoke(app, ["add", "test fact"])
+        assert result.exit_code == 1
+
+
+class TestAddBatch:
+    """Tests for add-batch command with mocked LLM."""
+
+    @patch("clawgraph.cli.Memory")
+    def test_add_batch_json(self, mock_mem_cls: MagicMock) -> None:
+        from clawgraph.memory import AddResult
+
+        mock_mem = MagicMock()
+        mock_mem.add_batch.return_value = AddResult(
+            entities=[{"name": "Bob", "label": "Person"}],
+            relationships=[],
+            executed=1,
+            errors=[],
+        )
+        mock_mem_cls.return_value = mock_mem
+
+        result = runner.invoke(
+            app, ["add-batch", "Bob is a person", "--output", "json"]
+        )
+        assert result.exit_code == 0
+
+
+class TestQuery:
+    """Tests for query command with mocked LLM."""
+
+    @patch("clawgraph.db.GraphDB")
+    @patch("clawgraph.llm.generate_cypher")
+    def test_query_json_output(
+        self, mock_gen: MagicMock, mock_db_cls: MagicMock
+    ) -> None:
+        mock_gen.return_value = "MATCH (e:Entity) RETURN e.name"
+        mock_db = MagicMock()
+        mock_db.execute.return_value = [{"e.name": "John"}]
+        mock_db_cls.return_value = mock_db
+
+        result = runner.invoke(
+            app, ["query", "Who is John?", "--output", "json"]
+        )
+        assert result.exit_code == 0
+        parsed = _extract_json(result.output)
+        assert parsed["count"] == 1


### PR DESCRIPTION
## Changes

### README
- Replace outdated LiteLLM references with OpenAI SDK

### Memory
- Add context manager support (\__enter__\/\__exit__\) for \with Memory() as mem:\ pattern

### CLI
- Fix \dd()\ to always output JSON when \--output json\ is used (was silently skipping in some code paths)
- Deduplicate \_find_label\: use \Memory._find_label\ instead of local copy
- Narrow \dd_batch\ exception handling from bare \Exception\ to \(LLMError, DatabaseError)\

### Tests
- Add \	ests/test_cli.py\ with 13 tests covering all CLI commands (version, config, ontology, export, add, add-batch, query)
- All 95 tests pass, ruff clean, mypy clean