### PR TITLE
docs: refresh project framing and architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ClawGraph
 
-> Graph-based memory abstraction layer for AI agents.
+> Local-first, embedded graph memory for AI agents.
 
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://python.org)
@@ -11,15 +11,34 @@
 
 ## What It Does
 
-ClawGraph converts natural language into graph memory. Tell it facts, it stores them in a local embedded graph database ([Kùzu](https://kuzudb.com/)). Ask it questions, it queries the graph and returns results.
+ClawGraph turns natural language into persistent graph memory. Tell it facts, it stores them in a local embedded graph database ([Kuzu](https://kuzudb.com/)). Ask it questions, it queries the graph and returns results.
+
+The project is currently focused on one clear lane: a small, inspectable, Python-first memory layer for agents that want structured recall without running separate infrastructure.
 
 - **Natural language in, graph memory out** — no Cypher knowledge required
-- **Embedded database** — no servers, no Docker, just a local file
+- **Local-first** — embedded Kuzu database, no server, no Docker, just a local file
+- **Inspectable** — query the graph directly, export JSON, inspect ontology evolution
 - **Automatic ontology** — the LLM infers and maintains your graph schema
 - **Python API** — `from clawgraph import Memory` for use in agentic loops
 - **Batch mode** — process multiple facts in a single LLM call
-- **Provider-agnostic** — works with any LLM via LiteLLM (OpenAI, Anthropic, etc.)
 - **Idempotent** — adding the same fact twice won't create duplicates
+
+## Current State
+
+ClawGraph is early-stage, but the core system is working and under active hardening.
+
+- Python package published on PyPI
+- Embedded persistence with snapshots and restore
+- JSON output across the CLI for agent use
+- Property-based and regression-tested core write/query paths
+- OpenAI-compatible LLM support today via the OpenAI SDK
+- Kuzu as the current database backend
+
+Planned direction:
+
+- broader LLM provider support beyond OpenAI-compatible APIs
+- additional database backends beyond Kuzu
+- better recall/context assembly for agent workflows
 
 ## Installation
 
@@ -59,7 +78,7 @@ clawgraph export graph.json
 clawgraph query "Who works at Acme?" --output json
 
 # Configure
-clawgraph config llm.model gpt-4o-mini
+clawgraph config llm.model gpt-5.4-mini
 clawgraph config                         # show all config
 ```
 
@@ -137,8 +156,8 @@ ClawGraph uses a **generic schema** — all entities are stored as `Entity(name,
 | Component | Library | Why |
 |-----------|---------|-----|
 | CLI | [Typer](https://typer.tiangolo.com/) | Type-hint driven, minimal boilerplate |
-| LLM | [LiteLLM](https://docs.litellm.ai/) | Any provider via one interface |
-| Graph DB | [Kùzu](https://kuzudb.com/) | Embedded, no server, native Cypher |
+| LLM | [OpenAI SDK](https://github.com/openai/openai-python) | OpenAI-compatible APIs today, simple direct integration |
+| Graph DB | [Kuzu](https://kuzudb.com/) | Embedded, no server, native Cypher |
 | Output | [Rich](https://rich.readthedocs.io/) | Tables, panels, colors |
 
 ## Configuration
@@ -147,7 +166,7 @@ Config lives at `~/.clawgraph/config.yaml`:
 
 ```yaml
 llm:
-  model: gpt-4o-mini
+  model: gpt-5.4-mini
   temperature: 0.0
 db:
   path: ~/.clawgraph/data
@@ -157,7 +176,7 @@ output:
 
 ### API Key Setup
 
-ClawGraph needs an API key from your LLM provider. There are three ways to provide it (in priority order):
+ClawGraph currently uses the OpenAI SDK and supports OpenAI-compatible endpoints. There are three ways to provide configuration (in priority order):
 
 **1. Project `.env` file (recommended)**
 
@@ -175,12 +194,12 @@ ClawGraph auto-loads `.env` from the current directory. This file takes preceden
 # OpenAI
 export OPENAI_API_KEY=sk-proj-...
 
-# Anthropic
-export ANTHROPIC_API_KEY=sk-ant-...
-
 # Azure OpenAI
 export AZURE_API_KEY=...
 export AZURE_API_BASE=https://your-resource.openai.azure.com/
+
+# Other OpenAI-compatible providers
+export OPENAI_BASE_URL=https://your-provider.example/v1
 ```
 
 **3. Config file**
@@ -188,30 +207,30 @@ export AZURE_API_BASE=https://your-resource.openai.azure.com/
 You can set the model (but not the key) via config:
 
 ```bash
-clawgraph config llm.model gpt-4o-mini
+clawgraph config llm.model gpt-5.4-mini
 ```
 
 ### Recommended Models
 
 | Model | Speed | Cost | Best for |
 |-------|-------|------|----------|
-| **`gpt-4o-mini`** | ~1s | ~$0.15/1M tokens | **Default.** Best balance of speed and accuracy for entity extraction. Recommended for agentic loops. |
-| `gpt-4o` | ~2-3s | ~$2.50/1M tokens | Higher accuracy on complex or ambiguous statements. |
-| `claude-3-5-haiku-latest` | ~1s | ~$0.25/1M tokens | Fast Anthropic alternative. |
-| `claude-sonnet-4-20250514` | ~2s | ~$3/1M tokens | Best Anthropic accuracy. |
+| **`gpt-5.4-mini`** | fast | moderate | **Recommended default.** Strong balance of speed and extraction quality for agent loops. |
+| `gpt-5.4` | slower | higher | Better choice for more ambiguous or higher-stakes extraction. |
 
-For agentic loops where you're calling `add()` frequently, **`gpt-4o-mini` is recommended** — it's fast enough for real-time use and accurate enough for entity extraction.
+For agentic loops where you're calling `add()` frequently, **`gpt-5.4-mini` is the recommended default**.
+
+Support for additional provider-specific presets will come later, but the near-term focus is making the OpenAI-compatible path solid and predictable.
 
 Override per-call with `--model`:
 
 ```bash
-clawgraph add "complex statement" --model gpt-4o
+clawgraph add "complex statement" --model gpt-5.4
 ```
 
 Or via the Python API:
 
 ```python
-mem = Memory(model="gpt-4o-mini")  # set once
+mem = Memory(model="gpt-5.4-mini")  # set once
 ```
 
 Data is stored at `~/.clawgraph/data` (Kùzu DB) and `~/.clawgraph/ontology.json`.

--- a/docs/architecture-gpt54.md
+++ b/docs/architecture-gpt54.md
@@ -1,0 +1,321 @@
+# ClawGraph - Architecture Snapshot
+
+> Last updated: 2026-04-03
+> Scope: current repository shape plus the runtime architecture of the published Python package
+
+This note is a current-state map of the repo as it exists today. It is not a roadmap. It is a description of what is actually wired up now.
+
+---
+
+## 1. Repository Map
+
+```mermaid
+graph TD
+    ROOT["clawgraph repo"]
+
+    ROOT --> SRC["src/clawgraph<br/>published Python package"]
+    ROOT --> TESTS["tests<br/>105 collected pytest tests"]
+    ROOT --> SKILL["skills/clawgraph/SKILL.md<br/>OpenClaw skill instructions"]
+    ROOT --> GYM["lobstergym<br/>evaluation harness + mock services"]
+    ROOT --> DOCS["docs<br/>architecture, roadmap, exploration notes"]
+    ROOT --> SITE["README.md + site/index.html<br/>project framing + landing page"]
+    ROOT --> BUILD["pyproject.toml + GitHub Actions<br/>package, lint, typing, CI"]
+
+    SRC --> CLI["cli.py<br/>Typer CLI"]
+    SRC --> MEM["memory.py<br/>high-level memory API"]
+    SRC --> LLM["llm.py<br/>OpenAI SDK integration"]
+    SRC --> DB["db.py<br/>Kuzu wrapper + snapshots"]
+    SRC --> ONT["ontology.py<br/>schema tracking"]
+    SRC --> CYPHER["cypher.py<br/>validation + sanitization"]
+    SRC --> CFG["config.py<br/>YAML config loader"]
+    SRC --> MAIN["__main__.py / __init__.py"]
+
+    GYM --> WEB["web<br/>Flask mock websites"]
+    GYM --> API["api<br/>FastAPI mock APIs"]
+    GYM --> EVAL["eval<br/>runner + tasks"]
+    GYM --> REPORTS["reports<br/>evaluation output"]
+    GYM --> COMPOSE["docker-compose.yml<br/>side-by-side profiles"]
+
+    style ROOT fill:#16213e,stroke:#e94560,color:#fff
+    style SRC fill:#0f3460,stroke:#e94560,color:#fff
+    style GYM fill:#0f3460,stroke:#e94560,color:#fff
+    style TESTS fill:#533483,stroke:#fff,color:#fff
+    style DOCS fill:#533483,stroke:#fff,color:#fff
+    style SKILL fill:#533483,stroke:#fff,color:#fff
+    style SITE fill:#533483,stroke:#fff,color:#fff
+    style BUILD fill:#533483,stroke:#fff,color:#fff
+```
+
+---
+
+## 2. Product Framing
+
+ClawGraph is currently best understood as a local-first graph memory layer for agents.
+
+The repo is doing four jobs at once:
+
+1. A Python package for persistent graph memory
+2. A CLI for storing and querying memory without writing code
+3. An OpenClaw skill / integration surface
+4. A LobsterGym-based evaluation setup for measuring memory effects
+
+The architectural bias is deliberate:
+
+1. Embedded storage over a hosted service
+2. Inspectable graph state over opaque memory blobs
+3. Small Python-first API over a broad platform surface
+4. OpenAI-compatible LLM support today, broader provider support later
+5. Kuzu today, additional database backends later
+
+---
+
+## 3. Core Runtime Architecture
+
+```mermaid
+graph LR
+    U1["CLI user"] --> CLI["cli.py"]
+    U2["Python agent/app"] --> MEM["Memory API"]
+    U3["OpenClaw skill"] --> MEM
+
+    CLI --> MEM
+    MEM --> ONT["Ontology"]
+    MEM --> LLM["LLM layer"]
+    MEM --> CYPHER["Cypher validation"]
+    MEM --> DB["GraphDB"]
+    LLM --> CFG["Config loader"]
+    LLM --> OPENAI["OpenAI SDK"]
+    OPENAI --> PROVIDER["OpenAI-compatible endpoint"]
+    DB --> KUZU["Kuzu embedded DB"]
+    ONT --> ONTFILE["ontology.json"]
+    CFG --> CFGFILE["config.yaml"]
+    DB --> DBFILES["~/.clawgraph/data"]
+    DB --> SNAP[".tar.gz snapshots"]
+
+    style CLI fill:#e94560,stroke:#fff,color:#fff
+    style MEM fill:#16213e,stroke:#e94560,color:#fff
+    style ONT fill:#533483,stroke:#fff,color:#fff
+    style LLM fill:#533483,stroke:#fff,color:#fff
+    style CYPHER fill:#533483,stroke:#fff,color:#fff
+    style DB fill:#533483,stroke:#fff,color:#fff
+    style OPENAI fill:#0f3460,stroke:#e94560,color:#fff
+    style PROVIDER fill:#0f3460,stroke:#e94560,color:#fff
+    style KUZU fill:#0f3460,stroke:#e94560,color:#fff
+```
+
+### Current boundaries
+
+- `memory.py` is the main orchestration layer
+- `db.py` owns Kuzu lifecycle, schema bootstrapping, and snapshot save/load
+- `llm.py` owns extraction and Cypher generation via the OpenAI SDK
+- `cypher.py` is the safety gate before execution
+- `ontology.py` persists the evolving schema used to guide future prompts
+
+---
+
+## 4. What Actually Happens on `add()` and `query()`
+
+```mermaid
+flowchart TD
+    A1["Natural-language fact<br/>e.g. 'Alice works at Acme'"] --> A2["Memory.add()"]
+    A2 --> A3["Ontology.to_context_string()<br/>current schema + constraints"]
+    A3 --> A4["llm.infer_ontology()<br/>extract entities + relationships"]
+    A4 --> A5["build_merge_cypher_groups()<br/>group logical writes"]
+    A5 --> A6["sanitize_cypher() + validate_cypher()"]
+    A6 --> A7["_execute_cypher_group()<br/>transactional group write"]
+    A7 --> A8["Kuzu persists Entity / Relates"]
+    A8 --> A9["Ontology updated with labels/types"]
+    A9 --> A10["AddResult returned"]
+
+    Q1["Natural-language question<br/>e.g. 'Who works at Acme?'"] --> Q2["Memory.query()"]
+    Q2 --> Q3["Ontology.to_context_string()"]
+    Q3 --> Q4["llm.generate_cypher(mode='read')"]
+    Q4 --> Q5["sanitize + validate"]
+    Q5 --> Q6["GraphDB.execute()"]
+    Q6 --> Q7["Rows returned as list[dict]"]
+
+    style A2 fill:#16213e,stroke:#e94560,color:#fff
+    style Q2 fill:#16213e,stroke:#e94560,color:#fff
+    style A7 fill:#533483,stroke:#fff,color:#fff
+    style Q6 fill:#533483,stroke:#fff,color:#fff
+```
+
+### Important current nuance
+
+Most write-oriented CLI behavior now routes through `Memory`, but `cli.py` still has some direct orchestration for read/query formatting. So the package architecture is cleaner than the CLI architecture in a few places.
+
+---
+
+## 5. Persistent State Model
+
+```mermaid
+graph TB
+    subgraph USERHOME["User home: ~/.clawgraph/"]
+        CFG["config.yaml<br/>model, db path, output format"]
+        ONT["ontology.json<br/>learned labels + relationship types"]
+        DBDIR["data<br/>Kuzu database files"]
+    end
+
+    subgraph DBSCHEMA["Logical Graph Schema"]
+        ENTITY["Entity<br/>name (PK)<br/>label<br/>created_at<br/>updated_at"]
+        REL["Relates<br/>type<br/>created_at"]
+        ENTITY -->|"Relates"| ENTITY2["Entity"]
+    end
+
+    SNAP["snapshot.tar.gz"] -. backup / restore .-> DBDIR
+    ENV[".env in cwd"] -. overrides .-> CFG
+
+    style USERHOME fill:#16213e,stroke:#e94560,color:#fff
+    style DBSCHEMA fill:#0f3460,stroke:#e94560,color:#fff
+    style SNAP fill:#533483,stroke:#fff,color:#fff
+    style ENV fill:#533483,stroke:#fff,color:#fff
+```
+
+### Current persistence assumptions
+
+1. Kuzu is the only shipping graph backend right now
+2. All entities are stored in a generic `Entity` table rather than domain-specific node tables
+3. All relationships are stored in a generic `Relates` table with `type` as data
+4. Timestamps are part of the core schema and are exercised by tests
+5. Snapshots are a first-class portability mechanism
+
+---
+
+## 6. Interfaces That Exist Today
+
+### Python API
+
+The `Memory` API is the primary product surface.
+
+Current high-value methods:
+
+1. `add()`
+2. `add_batch()`
+3. `query()`
+4. `entities()`
+5. `relationships()`
+6. `export()`
+7. `save_snapshot()`
+8. `from_snapshot()`
+
+### CLI
+
+Current CLI covers:
+
+1. `add`
+2. `add-batch`
+3. `query`
+4. `export`
+5. `ontology`
+6. `config`
+7. `--output json` flows for agent-facing usage
+
+### OpenClaw skill
+
+The repo still positions ClawGraph as a persistent memory substrate that can plug into OpenClaw-style agent workflows.
+
+---
+
+## 7. LobsterGym Evaluation Topology
+
+```mermaid
+graph TB
+    subgraph MOCKS["Deterministic task world"]
+        WEB["lobstergym-web :8080<br/>Flask sites<br/>flights / todos / contact / shop"]
+        API["lobstergym-api :8090<br/>FastAPI services<br/>weather / calendar / email / notes"]
+    end
+
+    subgraph AGENTS["Agents under test"]
+        OC1["OpenClaw + ClawGraph"]
+        OC2["OpenClaw baseline"]
+    end
+
+    subgraph HARNESS["Eval harness"]
+        TASKS["tasks.py<br/>task definitions"]
+        RUNNER["runner.py<br/>send task -> poll -> verify"]
+        REPORT["reports/*.json"]
+    end
+
+    RUNNER --> TASKS
+    RUNNER --> OC1
+    RUNNER --> OC2
+    OC1 --> WEB
+    OC1 --> API
+    OC1 --> MEM1["ClawGraph memory"]
+    OC2 --> WEB
+    OC2 --> API
+    RUNNER --> WEBSTATE["/state endpoints"]
+    RUNNER --> APISTATE["/state endpoints"]
+    RUNNER --> REPORT
+
+    style MOCKS fill:#16213e,stroke:#e94560,color:#fff
+    style AGENTS fill:#0f3460,stroke:#e94560,color:#fff
+    style HARNESS fill:#1a1a2e,stroke:#533483,color:#fff
+    style OC1 fill:#e94560,stroke:#fff,color:#fff
+    style OC2 fill:#533483,stroke:#fff,color:#fff
+```
+
+The important point is not just that LobsterGym exists. It is that the repo includes an environment intended to measure whether memory improves agent behavior instead of relying only on anecdotal demos.
+
+---
+
+## 8. Current Constraints
+
+The current repo state has a few important architectural constraints:
+
+1. LLM support is OpenAI-compatible today, not truly provider-generic yet
+2. Kuzu is the only production backend today
+3. The schema is intentionally generic and simple rather than semantically rich
+4. Query generation is LLM-driven and validated, but not deterministic in the way a hand-written query API would be
+5. Some repo areas mix product code, evaluation work, and strategy docs in the same workspace
+
+These are not necessarily problems. They are just the present shape of the system.
+
+---
+
+## 9. Mental Model
+
+```mermaid
+graph TD
+    R["This repo is really 4 things at once"]
+    R --> A["1. Python package<br/>local-first graph memory"]
+    R --> B["2. CLI<br/>human + agent-facing entry point"]
+    R --> C["3. OpenClaw integration<br/>memory substrate for agents"]
+    R --> D["4. Evaluation harness<br/>measure memory effects"]
+
+    A --> A1["Store facts as graph memory"]
+    A --> A2["Query with natural language"]
+    A --> A3["Persist locally, snapshot, export"]
+
+    B --> B1["Rich human output"]
+    B --> B2["JSON output for agent workflows"]
+
+    C --> C1["Persistent memory across tasks"]
+    C --> C2["Structured recall instead of flat chat history"]
+
+    D --> D1["Mock sites + APIs"]
+    D --> D2["Compare with and without ClawGraph"]
+
+    style R fill:#16213e,stroke:#e94560,color:#fff
+    style A fill:#e94560,stroke:#fff,color:#fff
+    style B fill:#0f3460,stroke:#e94560,color:#fff
+    style C fill:#533483,stroke:#fff,color:#fff
+    style D fill:#1a1a2e,stroke:#533483,color:#fff
+```
+
+---
+
+## Reading Order
+
+If you want to understand the repo quickly, use this order:
+
+1. [README.md](README.md)
+2. [src/clawgraph/memory.py](src/clawgraph/memory.py)
+3. [src/clawgraph/llm.py](src/clawgraph/llm.py)
+4. [src/clawgraph/db.py](src/clawgraph/db.py)
+5. [src/clawgraph/cli.py](src/clawgraph/cli.py)
+6. [tests/test_memory.py](tests/test_memory.py)
+7. [tests/test_cli.py](tests/test_cli.py)
+8. [lobstergym/README.md](lobstergym/README.md)
+9. [lobstergym/eval/runner.py](lobstergym/eval/runner.py)
+
+That path gives you: framing -> runtime -> persistence -> interface -> tests -> evaluation.

--- a/docs/feature-roadmap.md
+++ b/docs/feature-roadmap.md
@@ -1,7 +1,7 @@
 # ClawGraph — Feature Roadmap
 
-> Last updated: 2026-03-03
-> Status: Active development. v0.1.0 shipped. Persistence + LobsterGym in PR #2.
+> Last updated: 2026-04-03
+> Status: Active development. v0.1.2 shipped to PyPI. Main now includes post-release security and TDD hardening, with 105 tests in the current suite.
 
 ---
 
@@ -18,10 +18,142 @@ Agents or contributors can pick up any feature by creating the branch and workin
 
 ---
 
+## Completed Work (v0.1.0 → current main)
+
+The following shipped in v0.1.0–v0.1.2 and form the foundation for everything below:
+
+- [x] **Core memory API** — `add()`, `query()`, `export()`, `add_batch()` (Python + CLI)
+- [x] **Kùzu graph storage** — embedded, no server, MERGE-based idempotency
+- [x] **LLM extraction** — NL → entities/relationships via OpenAI SDK (any compatible API)
+- [x] **Ontology tracking** — auto-discovered schema, constraints, JSON persistence
+- [x] **Snapshots** — save/load DB as `.tar.gz` for portability
+- [x] **Timestamps** — `created_at`, `updated_at` on all entities and relationships
+- [x] **Batch mode** — multiple facts in one LLM call
+- [x] **JSON output** — `--output json` on all CLI commands
+- [x] **Context manager** — `with Memory() as mem:` (PR #37)
+- [x] **Security hardening** — injection prevention, path traversal protection, entity name validation, safe file permissions, info leak prevention (PR #36)
+- [x] **CI pipeline** — pytest matrix (3.10–3.13, ubuntu+windows), ruff, mypy, daily pip-audit
+- [x] **PyPI publishing** — Trusted Publishing (OIDC) + Sigstore attestations
+- [x] **LobsterGym eval** — Docker Compose eval framework with browser tasks
+- [x] **Write-path hardening** — explicit logical write groups plus transactional rollback on grouped write failure (PR #55)
+- [x] **105 tests** — all mocked, no live API calls in CI
+- [x] **Pre-commit hooks** — ruff + mypy (PR #24)
+- [x] **CLI tests** — 13 tests covering all commands (PR #37)
+
+### Open Draft PRs
+
+| PR | Feature | Branch | Status |
+|----|---------|--------|--------|
+| #8 | Memory decay | `copilot/add-memory-decay-feature` | Draft — deprioritized |
+| #10 | Confidence scoring | `copilot/add-confidence-scoring-relationships` | Draft |
+| #11 | Tool-use definitions | `copilot/feattool-definitions` | Draft |
+| #12 | Source provenance | `copilot/add-source-provenance-tracking` | Draft |
+| #14 | Tiered LLM models | `copilot/add-tiered-models-support` | Draft |
+| #15 | Workflow entity types | `copilot/add-workflow-step-tool-app-nodes` | Draft — deprioritized |
+
+### Recently Merged on Main
+
+- PR #36 — security hardening
+- PR #37 — codebase quality and CLI tests
+- PR #55 — TDD hardening for snapshot paths and grouped write execution
+
+---
+
 ## Milestone: v0.2.0 — "Memory That Works"
 
-**Goal:** Make ClawGraph production-ready for single-agent deployments.
-**Target:** 2026-03-10
+**Goal:** Make ClawGraph production-ready for single-agent deployments. The graph must have clean data, be queryable reliably, and integrate with any agent framework with zero friction.
+**Target:** 2026-04-15 (revised)
+
+### F21: Entity Resolution & Deduplication ⭐ NEW
+- **Priority:** P0
+- **Effort:** M
+- **Branch:** `feat/entity-resolution`
+- **Dependencies:** None
+- **Description:** Prevent semantic duplicates in the graph. "John Smith", "John", "john smith" should resolve to the same entity. Normalize names (case, whitespace, punctuation). Store aliases. On `add()`, check if an incoming entity is likely the same as an existing one (exact match after normalization → merge; close match → ask LLM to confirm). Without this, the graph fills with fragmented knowledge that never connects.
+- **Files to create/modify:**
+  - `src/clawgraph/db.py` — Add `aliases STRING` column to Entity, normalized name index
+  - `src/clawgraph/memory.py` — Entity resolution logic in `_execute_inferred()`, alias management
+  - `src/clawgraph/llm.py` — Optional LLM disambiguation ("Is 'JS' the same person as 'John Smith'?")
+  - `tests/test_entity_resolution.py`
+- **Acceptance criteria:**
+  - [ ] `mem.add("John Smith works at Acme")` then `mem.add("john smith lives in NYC")` → single entity
+  - [ ] Case/whitespace normalization happens automatically
+  - [ ] `mem.add("JS joined Acme")` with existing "John Smith" → LLM asked to disambiguate
+  - [ ] Entity aliases stored and searchable
+  - [ ] `mem.entities()` returns canonical names with aliases
+  - [ ] No regression on existing add/query behavior
+  - [ ] Tests verify normalization, alias storage, disambiguation
+
+---
+
+### F22: Recall API — Context Injection for Agents ⭐ NEW
+- **Priority:** P0
+- **Effort:** M
+- **Branch:** `feat/recall-api`
+- **Dependencies:** None (enhanced by F01)
+- **Description:** The API agents actually need. Instead of formulating precise queries, agents call `mem.recall(context="...", max_tokens=2000)` and get a pre-formatted block of relevant knowledge injected into their system prompt. This finds relevant entities via the LLM/graph, traverses 1–2 hops for related context, serializes as natural language, and trims to token budget. This is the difference between "a graph database wrapper" and "a memory system."
+- **Files to create/modify:**
+  - `src/clawgraph/memory.py` — Add `recall()` method
+  - `src/clawgraph/llm.py` — Relevance scoring prompt, context serialization
+  - `src/clawgraph/db.py` — Multi-hop traversal helper (`get_neighborhood(entity, hops=2)`)
+  - `src/clawgraph/cli.py` — `clawgraph recall "context"` CLI command
+  - `tests/test_recall.py`
+- **Acceptance criteria:**
+  - [ ] `mem.recall("user is asking about deployment")` returns relevant subgraph as formatted text
+  - [ ] Result respects `max_tokens` budget (approximate, truncates least-relevant facts)
+  - [ ] Traverses 1–2 hops from matched entities (e.g., find "deployment" → also returns team, tools, dates)
+  - [ ] Returns empty string gracefully if nothing relevant found
+  - [ ] Output format is agent-friendly (structured text, not raw JSON)
+  - [ ] `clawgraph recall "context" --max-tokens 1000` CLI command works
+  - [ ] Tests with mocked LLM and pre-populated graph
+
+---
+
+### F23: Relationship Properties ⭐ NEW
+- **Priority:** P1
+- **Effort:** M
+- **Branch:** `feat/relationship-properties`
+- **Dependencies:** None
+- **Description:** The current `Relates` table only stores `type` and `created_at`. Real knowledge needs richer edges: "Alice was CEO of Acme from 2020 to 2024", "Bob knows Alice well (strength: 0.9)". Add a `properties JSON` column (or typed columns) for temporal qualifiers, strength, and arbitrary metadata. Update LLM extraction prompts to pull properties from statements.
+- **Files to create/modify:**
+  - `src/clawgraph/db.py` — Add `properties STRING` (JSON) column to Relates, migration
+  - `src/clawgraph/llm.py` — Update extraction prompt to include relationship properties (dates, qualifiers)
+  - `src/clawgraph/memory.py` — Pass properties through `_execute_inferred()`
+  - `tests/test_relationship_properties.py`
+- **Acceptance criteria:**
+  - [ ] `mem.add("Alice was CEO of Acme from 2020 to 2024")` stores `{"from": "2020", "to": "2024"}` on relationship
+  - [ ] `mem.relationships()` includes properties in output
+  - [ ] Export includes relationship properties
+  - [ ] Query results include relationship properties
+  - [ ] Migration adds column to existing DBs without data loss
+  - [ ] LLM prompt updated to extract temporal/qualifier info
+  - [ ] Tests verify storage, retrieval, and migration
+
+---
+
+### F24: Delete / Retract / Correct ⭐ NEW
+- **Priority:** P0
+- **Effort:** S
+- **Branch:** `feat/delete-retract`
+- **Dependencies:** None
+- **Description:** There's currently no way to remove or correct a fact. Agents make mistakes. People change jobs. If the graph only grows and never corrects, it becomes unreliable. Add `mem.retract(statement)` (LLM identifies what to remove), `mem.delete_entity(name)` (cascade delete entity + all relationships), and `mem.update(old, new)` (retract + add).
+- **Files to create/modify:**
+  - `src/clawgraph/memory.py` — Add `retract()`, `delete_entity()`, `update()` methods
+  - `src/clawgraph/db.py` — Add `delete_entity(name)`, `delete_relationship(from, to, type)` methods
+  - `src/clawgraph/llm.py` — Add retraction prompt (NL → identify entities/rels to remove)
+  - `src/clawgraph/cli.py` — `clawgraph delete <entity>`, `clawgraph retract "statement"` commands
+  - `tests/test_delete.py`
+- **Acceptance criteria:**
+  - [ ] `mem.delete_entity("Alice")` removes entity and all its relationships
+  - [ ] `mem.retract("Alice works at Acme")` removes the specific relationship
+  - [ ] `mem.update("Alice works at Acme", "Alice works at NewCo")` replaces the fact
+  - [ ] `clawgraph delete Alice` CLI command works (with confirmation prompt)
+  - [ ] `clawgraph retract "Alice works at Acme"` CLI command works
+  - [ ] Cascade delete doesn't leave orphaned relationships
+  - [ ] Ontology updated when last entity of a label type is removed
+  - [ ] Tests verify delete, retract, update, and cascade behavior
+
+---
 
 ### F01: Hybrid Retrieval (Graph + Vector Search)
 - **Priority:** P0
@@ -48,9 +180,10 @@ Agents or contributors can pick up any feature by creating the branch and workin
 ---
 
 ### F02: Confidence Scoring
-- **Priority:** P1
+- **Priority:** P2
 - **Effort:** M
 - **Branch:** `feat/confidence-scoring`
+- **Status:** PR #10 open (draft)
 - **Dependencies:** None
 - **Description:** Attach a confidence score (0.0–1.0) to each relationship. The LLM should estimate confidence during extraction. Low-confidence facts can be filtered or flagged.
 - **Files to create/modify:**
@@ -71,6 +204,7 @@ Agents or contributors can pick up any feature by creating the branch and workin
 - **Priority:** P1
 - **Effort:** M
 - **Branch:** `feat/source-provenance`
+- **Status:** PR #12 open (draft)
 - **Dependencies:** None
 - **Description:** Track where each fact came from — which agent session, tool call, or user input. Store as properties on relationships: `source_agent`, `source_session`, `source_input`.
 - **Files to create/modify:**
@@ -87,10 +221,11 @@ Agents or contributors can pick up any feature by creating the branch and workin
 ---
 
 ### F04: Memory Decay / Garbage Collection
-- **Priority:** P2
+- **Priority:** P3
 - **Effort:** M
 - **Branch:** `feat/memory-decay`
-- **Dependencies:** Timestamps (already shipped in persistence PR)
+- **Status:** PR #8 open (draft)
+- **Dependencies:** Timestamps (shipped), Entity resolution (F21)
 - **Description:** Auto-demote or remove stale facts based on age and access frequency. Add an `access_count` property that increments on query hits. Provide `mem.prune(max_age_days=90, min_access_count=1)`.
 - **Files to create/modify:**
   - `src/clawgraph/db.py` — Add `access_count INT DEFAULT 0`, `last_accessed STRING` to Entity
@@ -110,6 +245,7 @@ Agents or contributors can pick up any feature by creating the branch and workin
 - **Priority:** P1
 - **Effort:** S
 - **Branch:** `feat/tool-definitions`
+- **Status:** PR #11 open (draft)
 - **Dependencies:** None
 - **Description:** Export ClawGraph operations as OpenAI/Anthropic function-calling tool definitions (JSON Schema). Any LLM-based agent can then call ClawGraph natively without the OpenClaw skill.
 - **Files to create/modify:**
@@ -128,12 +264,13 @@ Agents or contributors can pick up any feature by creating the branch and workin
 ## Milestone: v0.3.0 — "Workflow Memory"
 
 **Goal:** Agents can record, recall, and learn from multi-step workflows.
-**Target:** 2026-03-20
+**Target:** 2026-05-01 (revised — core memory quality comes first)
 
 ### F06: Workflow Entity Types
-- **Priority:** P0
+- **Priority:** P2
 - **Effort:** M
 - **Branch:** `feat/workflow-entities`
+- **Status:** PR #15 open (draft) — deprioritized until core memory is solid
 - **Dependencies:** None
 - **Description:** Add `Workflow`, `Step`, `Tool`, `Application` node types to the base ontology. Define relationship types: `HAS_STEP`, `USED_TOOL`, `NEXT`, `ACCESSED_APP`.
 - **Files to create/modify:**
@@ -150,7 +287,7 @@ Agents or contributors can pick up any feature by creating the branch and workin
 ---
 
 ### F07: Workflow Logging API
-- **Priority:** P0
+- **Priority:** P2
 - **Effort:** L
 - **Branch:** `feat/workflow-logging`
 - **Dependencies:** F06
@@ -170,10 +307,10 @@ Agents or contributors can pick up any feature by creating the branch and workin
 ---
 
 ### F08: Workflow Retrieval
-- **Priority:** P1
+- **Priority:** P2
 - **Effort:** M
 - **Branch:** `feat/workflow-retrieval`
-- **Dependencies:** F06, F07
+- **Dependencies:** F06, F07, F22 (recall API patterns)
 - **Description:** `Memory.find_workflows(query)` — search for past workflows by natural language. Uses LLM to convert query to Cypher over workflow subgraph.
 - **Files to create/modify:**
   - `src/clawgraph/memory.py` — Add `find_workflows()`, `get_workflow(id)`
@@ -206,28 +343,28 @@ Agents or contributors can pick up any feature by creating the branch and workin
 
 ---
 
-## Milestone: v0.4.0 — "Multi-Agent Memory"
+## Milestone: v0.4.0 — "Scoped Memory"
 
-**Goal:** Multiple agents can share memory with access controls.
-**Target:** 2026-04-05
+**Goal:** One local agent can keep memory isolated across workflows, tasks, and threads; if shared deployments become important later, this milestone can extend into collaboration controls.
+**Target:** TBD after v0.3.0 priorities settle
 
-### F10: Namespaced Memory
+### F10: Workflow / Task / Thread Scoping
 - **Priority:** P0
 - **Effort:** L
-- **Branch:** `feat/namespaced-memory`
+- **Branch:** `feat/memory-scoping`
 - **Dependencies:** None
-- **Description:** Support `Memory(namespace="team-X")` — each namespace gets its own isolated graph in the same Kùzu DB (or separate DB directory). Agents in the same namespace share knowledge.
+- **Description:** Support `Memory(scope="deploy-incident-123")` or equivalent explicit workflow/task/thread scoping so one agent can keep separate jobs isolated without spinning up separate repos or databases. Scopes can map to the same Kuzu DB with metadata-based filtering or separate DB directories, but the user-facing goal is simple: memory for job A should not leak into job B unless asked.
 - **Files to create/modify:**
-  - `src/clawgraph/db.py` — Namespace-aware schema (prefix tables or separate directories)
-  - `src/clawgraph/memory.py` — Accept `namespace` param, scope all operations
-  - `src/clawgraph/config.py` — Default namespace config
-  - `tests/test_namespaces.py`
+  - `src/clawgraph/db.py` — Scope-aware storage model (metadata filter or separate directories)
+  - `src/clawgraph/memory.py` — Accept `scope` param, scope all operations
+  - `src/clawgraph/config.py` — Default scope config
+  - `tests/test_scoping.py`
 - **Acceptance criteria:**
-  - [ ] `Memory(namespace="team-a")` isolates from `Memory(namespace="team-b")`
-  - [ ] Default namespace is `"default"` (backward compatible)
-  - [ ] `mem.entities()` only returns entities from the active namespace
-  - [ ] `mem.query()` scopes to namespace
-  - [ ] Snapshots include namespace metadata
+  - [ ] `Memory(scope="task-a")` isolates from `Memory(scope="task-b")`
+  - [ ] Default scope is `"default"` (backward compatible)
+  - [ ] `mem.entities()` only returns entities from the active scope
+  - [ ] `mem.query()` scopes to the active workflow/task/thread
+  - [ ] Snapshots include scope metadata
   - [ ] Tests verify isolation and scoping
 
 ---
@@ -237,15 +374,15 @@ Agents or contributors can pick up any feature by creating the branch and workin
 - **Effort:** L
 - **Branch:** `feat/access-control`
 - **Dependencies:** F10, F03 (source provenance)
-- **Description:** Define who can read/write/admin each namespace. Identity is established by an agent ID or API key passed at init time.
+- **Description:** If shared deployments become a real use case, define who can read/write/admin each scope. Identity is established by an agent ID or API key passed at init time.
 - **Files to create/modify:**
   - `src/clawgraph/auth.py` — Access control model (AgentIdentity, Permission, ACL)
   - `src/clawgraph/memory.py` — Enforce permissions on all operations
   - `src/clawgraph/config.py` — ACL config in YAML
   - `tests/test_access_control.py`
 - **Acceptance criteria:**
-  - [ ] `Memory(namespace="team-a", agent_id="agent-1")` establishes identity
-  - [ ] Namespace creator has admin permissions
+  - [ ] `Memory(scope="shared-team-a", agent_id="agent-1")` establishes identity
+  - [ ] Scope creator has admin permissions
   - [ ] Read/write/admin permissions are enforceable
   - [ ] Unauthorized operations raise `PermissionError`
   - [ ] ACL changes are audited
@@ -279,7 +416,7 @@ Agents or contributors can pick up any feature by creating the branch and workin
 - **Effort:** M
 - **Branch:** `feat/privacy-controls`
 - **Dependencies:** F10, F11
-- **Description:** Mark facts as `private` (agent-local), `team` (namespace), or `public`. Implement `mem.forget(entity_name)` to purge an entity and all its relationships across all namespaces. GDPR-style compliance.
+- **Description:** If shared scopes emerge later, mark facts as `private` (agent-local), `scope`, or `public`. Implement `mem.forget(entity_name)` to purge an entity and all its relationships across all scopes. GDPR-style compliance.
 - **Files to create/modify:**
   - `src/clawgraph/memory.py` — Add `visibility` param to `add()`, `forget()` method
   - `src/clawgraph/db.py` — Visibility column, cascade delete
@@ -287,7 +424,7 @@ Agents or contributors can pick up any feature by creating the branch and workin
 - **Acceptance criteria:**
   - [ ] `mem.add("fact", visibility="private")` restricts to current agent only
   - [ ] `mem.forget("Alice")` removes Alice and all relationships
-  - [ ] Forget cascades across namespaces if agent has admin
+  - [ ] Forget cascades across scopes if agent has admin
   - [ ] Forget is logged in audit trail
   - [ ] Tests verify visibility filtering and cascade delete
 
@@ -405,7 +542,7 @@ Agents or contributors can pick up any feature by creating the branch and workin
 - **Priority:** P2
 - **Effort:** XL
 - **Branch:** `feat/plugin-architecture`
-- **Dependencies:** F01 (hybrid retrieval), F10 (namespaces)
+- **Dependencies:** F01 (hybrid retrieval), F10 (scoping)
 - **Description:** Define a `MemoryProvider` protocol that other frameworks can implement. ClawGraph becomes one implementation. Allow swapping backends (Kùzu, Neo4j, in-memory) and retrieval strategies (graph-only, vector-only, hybrid) via configuration.
 - **Files to create/modify:**
   - `src/clawgraph/protocol.py` — `MemoryProvider` abstract protocol
@@ -425,7 +562,7 @@ Agents or contributors can pick up any feature by creating the branch and workin
 - **Priority:** P3
 - **Effort:** L
 - **Branch:** `feat/encryption-at-rest`
-- **Dependencies:** F10 (namespaces)
+- **Dependencies:** F10 (scoping)
 - **Description:** Encrypt sensitive facts in the DB. Use symmetric encryption (Fernet/AES-256). Key management via environment variable or config.
 - **Files to create/modify:**
   - `src/clawgraph/crypto.py` — Encrypt/decrypt helpers
@@ -444,59 +581,62 @@ Agents or contributors can pick up any feature by creating the branch and workin
 
 ## Quick Wins (any time, low effort)
 
-| ID | Task | Effort | Branch |
-|----|------|--------|--------|
-| QW01 | Add CI badge to README | S | `chore/ci-badge` |
-| QW02 | CONTRIBUTING.md | S | `docs/contributing` |
-| QW03 | Enable GitHub Discussions | S | (repo settings, no branch needed) |
-| QW04 | README demo GIF (asciinema/VHS) | S | `docs/demo-gif` |
-| QW05 | `clawgraph version` CLI command | S | `feat/version-command` |
-| QW06 | `clawgraph stats` — entity/relationship counts | S | `feat/stats-command` |
-| QW07 | `clawgraph delete` — remove entity by name | S | `feat/delete-command` |
-| QW08 | `clawgraph clear` — wipe all data (with confirmation) | S | `feat/clear-command` |
-| QW09 | Better error messages for missing API keys | S | `fix/api-key-errors` |
-| QW10 | Pre-commit hook config (ruff + mypy) | S | `chore/pre-commit` |
+| ID | Task | Effort | Branch | Status |
+|----|------|--------|--------|--------|
+| QW01 | Add CI badge to README | S | `chore/ci-badge` | |
+| QW02 | CONTRIBUTING.md | S | `docs/contributing` | |
+| QW03 | Enable GitHub Discussions | S | (repo settings) | |
+| QW04 | README demo GIF (asciinema/VHS) | S | `docs/demo-gif` | |
+| QW05 | `clawgraph version` CLI command | S | `feat/version-command` | ✅ shipped (--version flag) |
+| QW06 | `clawgraph stats` — entity/relationship counts | S | `feat/stats-command` | |
+| QW07 | `clawgraph delete` — remove entity by name | S | `feat/delete-command` | → see F24 |
+| QW08 | `clawgraph clear` — wipe all data (with confirmation) | S | `feat/clear-command` | |
+| QW09 | Better error messages for missing API keys | S | `fix/api-key-errors` | |
+| QW10 | Pre-commit hook config (ruff + mypy) | S | `chore/pre-commit` | ✅ shipped (PR #24) |
 
 ---
 
 ## Priority Matrix
 
 ```
-            ┌───────────────────────────────────────────────┐
-            │           IMPACT                               │
-            │   High                           Low           │
-        ────┼───────────────────────────────────────────────┤
-  HIGH  U   │ F01 Hybrid Retrieval      F05 Tool Defs       │
-  R     R   │ F06 Workflow Entities      F09 Wf Analytics    │
-  G     G   │ F07 Workflow Logging       QW01-QW10           │
-  E     E   │ F10 Namespaced Memory                          │
-  N     N   │ F14 Task Expansion                             │
-  C     C   │                                                │
-  Y     Y   ├────────────────────────────────────────────────┤
-        ────│ F02 Confidence Scoring     F15 Eval Dashboard  │
-  LOW       │ F03 Source Provenance      F16 GHCR Images     │
-            │ F08 Wf Retrieval           F20 Encryption      │
-            │ F11 Access Control                             │
-            │ F12 Audit Log                                  │
-            │ F13 Privacy Controls                           │
-            │ F17 Schema Evolution                           │
-            │ F18 Docs Site                                  │
-            │ F19 Plugin Architecture                        │
-            └────────────────────────────────────────────────┘
+            ┌───────────────────────────────────────────────────┐
+            │           IMPACT                                   │
+            │   High                             Low             │
+        ────┼───────────────────────────────────────────────────┤
+  HIGH  U   │ F21 Entity Resolution       F05 Tool Defs         │
+  R     R   │ F22 Recall API              F09 Wf Analytics      │
+  G     G   │ F01 Hybrid Retrieval        QW01-QW10             │
+  E     E   │ F24 Delete/Retract                                │
+  N     N   │ F03 Source Provenance                              │
+  C     C   │                                                    │
+  Y     Y   ├────────────────────────────────────────────────────┤
+        ────│ F23 Relationship Properties  F15 Eval Dashboard   │
+  LOW       │ F02 Confidence Scoring       F16 GHCR Images      │
+            │ F06 Workflow Entities         F20 Encryption       │
+            │ F07 Workflow Logging          F04 Memory Decay     │
+            │ F10 Workflow / Task / Thread Scoping               │
+            │ F17 Schema Evolution                               │
+            │ F18 Docs Site                                      │
+            │ F19 Plugin Architecture                            │
+            └────────────────────────────────────────────────────┘
 ```
 
 ## Suggested Agent Assignment Order
 
 For overnight / async agent work, assign in this order:
 
-1. **Quick Wins batch** (QW01–QW10) — low risk, high volume, builds momentum
-2. **F05: Tool Definitions** — small, self-contained, immediately useful
-3. **F02: Confidence Scoring** — medium, teaches agents the codebase patterns
-4. **F03: Source Provenance** — medium, similar pattern to F02
-5. **F01: Hybrid Retrieval** — large, high-impact, core differentiator
-6. **F06 + F07: Workflow Entities + Logging** — large, sequential dependency
-7. **F14: LobsterGym Task Expansion** — can run in parallel with F06/F07
-8. **F10: Namespaced Memory** — large, unlocks multi-agent features
+1. **F21: Entity Resolution** — data quality foundation, everything downstream depends on it
+2. **F24: Delete / Retract / Correct** — small, essential for memory accuracy
+3. **F22: Recall API** — the actual API agents need for context injection
+4. **F05: Tool Definitions** (PR #11) — small, self-contained, unlocks zero-friction integration
+5. **F03: Source Provenance** (PR #12) — medium, trust layer for facts
+6. **F01: Hybrid Retrieval** — large, high-impact, core differentiator
+7. **F23: Relationship Properties** — medium, enriches graph expressiveness
+8. **F02: Confidence Scoring** (PR #10) — medium, quality signal on facts
+9. **Quick Wins batch** (QW01–QW10) — low risk, polish, builds adoption
+10. **F06 + F07: Workflow Entities + Logging** — large, sequential dependency
+11. **F10: Workflow / Task / Thread Scoping** — large, unlocks scoped-memory and later shared-memory features
+12. **F14: LobsterGym Task Expansion** — can run in parallel with above
 
 Features F11–F13, F17–F20 should wait until earlier features are merged and stable.
 

--- a/site/index.html
+++ b/site/index.html
@@ -3,11 +3,11 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>ClawGraph — Graph-based memory for AI agents</title>
-  <meta name="description" content="ClawGraph converts natural language into graph memory. An embedded graph database for AI agents — no servers, no Docker, just a local file.">
+  <title>ClawGraph — Local-first graph memory for AI agents</title>
+  <meta name="description" content="ClawGraph is local-first, embedded graph memory for AI agents. Structured recall, no server, no Docker, just a local file.">
   <meta name="keywords" content="clawgraph, graph memory, AI agents, knowledge graph, embedded database, kuzu, python, openclaw">
-  <meta property="og:title" content="ClawGraph — Graph-based memory for AI agents">
-  <meta property="og:description" content="Natural language in, graph memory out. An embedded graph database for AI agents.">
+  <meta property="og:title" content="ClawGraph — Local-first graph memory for AI agents">
+  <meta property="og:description" content="Natural language in, structured graph memory out. Local-first agent memory with an embedded database.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://clawgraph.github.io/clawgraph/">
   <link rel="canonical" href="https://clawgraph.github.io/clawgraph/">
@@ -81,7 +81,7 @@
   <div class="container">
     <header>
       <h1>ClawGraph</h1>
-      <p>Graph-based memory for AI agents</p>
+      <p>Local-first, embedded graph memory for AI agents</p>
       <div class="badges">
         <a href="https://pypi.org/project/clawgraph/"><img src="https://img.shields.io/pypi/v/clawgraph.svg" alt="PyPI"></a>
         <a href="https://github.com/clawgraph/clawgraph/actions/workflows/test.yml"><img src="https://github.com/clawgraph/clawgraph/actions/workflows/test.yml/badge.svg" alt="Tests"></a>
@@ -94,29 +94,35 @@
       <div class="features">
         <div class="feature">
           <h3>Natural Language In</h3>
-          <p>Tell it facts in plain English. The LLM converts them to graph structures automatically.</p>
+          <p>Tell it facts in plain English. ClawGraph turns them into structured graph memory automatically.</p>
         </div>
         <div class="feature">
-          <h3>Graph Memory Out</h3>
-          <p>Stored in an embedded Kùzu database. No servers, no Docker, just a local file.</p>
+          <h3>Local-First Storage</h3>
+          <p>Stored in an embedded Kuzu database. No servers, no Docker, just a local file.</p>
         </div>
         <div class="feature">
           <h3>Automatic Ontology</h3>
           <p>The LLM infers and maintains your graph schema as you add facts.</p>
         </div>
         <div class="feature">
+          <h3>Inspectable</h3>
+          <p>Query the graph directly, export JSON, and inspect how memory is actually being stored.</p>
+        </div>
+        <div class="feature">
           <h3>Python API</h3>
           <p>Drop into any agentic loop with <code>from clawgraph import Memory</code>.</p>
         </div>
         <div class="feature">
-          <h3>Idempotent</h3>
-          <p>Adding the same fact twice won't create duplicates. Uses MERGE, not CREATE.</p>
-        </div>
-        <div class="feature">
-          <h3>Provider Agnostic</h3>
-          <p>Works with any OpenAI-compatible API — OpenAI, Azure, local LLMs.</p>
+          <h3>Focused Today, Broader Later</h3>
+          <p>Today: OpenAI-compatible APIs and Kuzu. Future: broader LLM providers and additional database backends.</p>
         </div>
       </div>
+    </section>
+
+    <section>
+      <h2>Project Framing</h2>
+      <p>ClawGraph is aimed at one specific lane: a small, Python-first memory layer for agents that want structured recall without running separate infrastructure.</p>
+      <p>Instead of trying to be a full memory platform, it focuses on being local, inspectable, and easy to drop into agent workflows.</p>
     </section>
 
     <section>
@@ -137,7 +143,10 @@ clawgraph query "Where does John work?"
 clawgraph add-batch "Bob is a designer" "Bob works at Netflix"
 
 <span class="install"># JSON output for agents</span>
-clawgraph query "Who works at Acme?" --output json</code></pre>
+clawgraph query "Who works at Acme?" --output json
+
+<span class="install"># Recommended model</span>
+clawgraph config llm.model gpt-5.4-mini</code></pre>
     </section>
 
     <section>
@@ -148,6 +157,17 @@ with Memory() as mem:
     mem.add("John works at Acme Corp")
     mem.add("Alice is a data scientist at Google")
     results = mem.query("Who works at Acme?")</code></pre>
+    </section>
+
+    <section>
+      <h2>Current Defaults</h2>
+      <pre><code>llm:
+  model: gpt-5.4-mini
+  temperature: 0.0
+
+db:
+  path: ~/.clawgraph/data</code></pre>
+      <p>Recommended today: <code>gpt-5.4-mini</code> for fast agent loops. Higher-end models can be used for more ambiguous extraction workloads.</p>
     </section>
 
     <div class="links">


### PR DESCRIPTION
## Summary
- refresh the README and landing page to reflect the local-first, embedded graph memory positioning
- add a current architecture snapshot for the repo and runtime shape
- update the roadmap to match current main, merged PRs, and the scoped-memory direction

## Testing
- not run (docs/site only)
