### PR TITLE
Prepare 0.1.3 publish and ClawHub skill

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "clawgraph"
-version = "0.1.2"
+version = "0.1.3"
 description = "Graph-based memory abstraction layer for AI agents"
 readme = "README.md"
 license = "Apache-2.0"

--- a/skills/clawgraph/SKILL.md
+++ b/skills/clawgraph/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: clawgraph
 description: Automatically store explicit durable user facts and recall them later; do not infer or upgrade weak signals
-version: 0.1.1
-metadata: {"openclaw": {"requires": {"bins": ["clawgraph"], "env": ["OPENAI_API_KEY"]}, "primaryEnv": "OPENAI_API_KEY", "install": [{"id": "pip", "kind": "node", "label": "Install ClawGraph (pip)", "bins": ["clawgraph"]}]}}
+homepage: https://github.com/clawgraph/clawgraph
+version: 0.1.3
+metadata: {"openclaw": {"emoji": "🧠", "requires": {"bins": ["clawgraph"], "env": ["OPENAI_API_KEY"]}, "primaryEnv": "OPENAI_API_KEY", "install": [{"id": "uv", "kind": "uv", "package": "clawgraph==0.1.3", "label": "Install ClawGraph (uv)", "bins": ["clawgraph"]}]}}
 tags:
   - memory
   - knowledge-graph

--- a/src/clawgraph/__init__.py
+++ b/src/clawgraph/__init__.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 
 
 def __getattr__(name: str) -> Any:

--- a/tests/test_devcontainer_docs.py
+++ b/tests/test_devcontainer_docs.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+import tomllib
+
 
 def test_openclaw_gateway_service_uses_bootstrap_script() -> None:
     compose_path = Path(".devcontainer/docker-compose.test.yml")
@@ -96,6 +98,34 @@ def test_clawgraph_skill_requires_high_confidence_fact_storage() -> None:
     assert "Preserve the user's phrasing when possible" in skill_text
     assert "OpenAI-compatible APIs today" in skill_text
     assert "LiteLLM" not in skill_text
+
+
+def test_clawgraph_skill_is_ready_for_clawhub_distribution() -> None:
+    skill_path = Path("skills/clawgraph/SKILL.md")
+    pyproject_path = Path("pyproject.toml")
+
+    skill_text = skill_path.read_text(encoding="utf-8")
+    project_version = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))["project"]["version"]
+
+    assert "homepage: https://github.com/clawgraph/clawgraph" in skill_text
+    assert '"emoji": "🧠"' in skill_text
+    assert '"kind": "uv"' in skill_text
+    assert f'"package": "clawgraph=={project_version}"' in skill_text
+    assert '"kind": "node"' not in skill_text
+
+
+def test_release_version_is_consistent() -> None:
+    pyproject_path = Path("pyproject.toml")
+    init_path = Path("src/clawgraph/__init__.py")
+    skill_path = Path("skills/clawgraph/SKILL.md")
+
+    project_version = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))["project"]["version"]
+    init_text = init_path.read_text(encoding="utf-8")
+    skill_text = skill_path.read_text(encoding="utf-8")
+
+    assert f'__version__ = "{project_version}"' in init_text
+    assert f"version: {project_version}" in skill_text
+    assert f'"package": "clawgraph=={project_version}"' in skill_text
 
 
 def test_main_readme_includes_verified_openclaw_walkthrough() -> None:


### PR DESCRIPTION
## Summary
- bump the Python package version to 0.1.3
- align `src/clawgraph/__init__.py` and the OpenClaw skill metadata with the same release version
- make the ClawGraph OpenClaw skill ClawHub-ready with homepage, emoji, and a real `uv` installer spec
- add regression coverage so package version, module version, and skill installer version stay aligned

## Verification
- python -m pytest
- python -m ruff check src/ tests/
- python -m build
- python -m twine check dist/*

## Follow-up
- after merge, publish `clawgraph==0.1.3` to PyPI
- publish the `skills/clawgraph` bundle to ClawHub so OpenClaw users can install it with `openclaw skills install`